### PR TITLE
Use ApplicativeDo and RecordWildCards

### DIFF
--- a/benchmarks/bench.hs
+++ b/benchmarks/bench.hs
@@ -10,13 +10,16 @@ import qualified Data.Text as Text
 import qualified Text.Heredoc as Heredoc
 
 main :: IO ()
-main = C.defaultMain
-  [ C.bench "parseDocument" (C.nf parseDocument text)
-  , C.bench "prettyPrintDocument" (C.nf prettyPrintDocument document)
-  ]
+main =
+  C.defaultMain
+    [ C.bench "parseDocument" (C.nf parseDocument text)
+    , C.bench "prettyPrintDocument" (C.nf prettyPrintDocument document)
+    ]
 
 text :: Text
-text = Text.pack [Heredoc.here|
+text =
+  Text.pack
+    [Heredoc.here|
 # https://github.com/graphql/graphql-js/blob/c4f26569acdb9a7dfbceb48b9786b46d65a4b11b/src/language/__tests__/kitchen-sink.graphql
 # Copyright (c) 2015, Facebook, Inc.
 # All rights reserved.

--- a/library/Grotesque/Language.hs
+++ b/library/Grotesque/Language.hs
@@ -4,12 +4,10 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.Scientific (Scientific)
 import Data.Text (Text)
 
-
 -- | <https://facebook.github.io/graphql/#Document>
 newtype Document = Document
   { documentValue :: [Definition]
   } deriving (Eq, Show)
-
 
 -- | <https://facebook.github.io/graphql/#Definition>
 data Definition
@@ -17,7 +15,6 @@ data Definition
   | DefinitionFragment FragmentDefinition
   | DefinitionTypeSystem TypeSystemDefinition
   deriving (Eq, Show)
-
 
 -- | <https://facebook.github.io/graphql/#OperationDefinition>
 data OperationDefinition = OperationDefinition
@@ -28,7 +25,6 @@ data OperationDefinition = OperationDefinition
   , operationDefinitionSelectionSet :: SelectionSet
   } deriving (Eq, Show)
 
-
 -- | <https://facebook.github.io/graphql/#OperationType>
 data OperationType
   = OperationTypeQuery
@@ -36,18 +32,15 @@ data OperationType
   | OperationTypeSubscription
   deriving (Bounded, Enum, Eq, Show)
 
-
 -- | <https://facebook.github.io/graphql/#Name>
 newtype Name = Name
   { nameValue :: Text
   } deriving (Eq, Show)
 
-
 -- | <https://facebook.github.io/graphql/#VariableDefinitions>
 newtype VariableDefinitions = VariableDefinitions
   { variableDefinitionsValue :: [VariableDefinition]
   } deriving (Eq, Show)
-
 
 -- | <https://facebook.github.io/graphql/#VariableDefinition>
 data VariableDefinition = VariableDefinition
@@ -56,12 +49,10 @@ data VariableDefinition = VariableDefinition
   , variableDefinitionDefaultValue :: Maybe DefaultValue
   } deriving (Eq, Show)
 
-
 -- | <https://facebook.github.io/graphql/#Variable>
 newtype Variable = Variable
   { variableValue :: Name
   } deriving (Eq, Show)
-
 
 -- | <https://facebook.github.io/graphql/#Type>
 data Type
@@ -70,18 +61,15 @@ data Type
   | TypeNonNull NonNullType
   deriving (Eq, Show)
 
-
 -- | <https://facebook.github.io/graphql/#NamedType>
 newtype NamedType = NamedType
   { namedTypeValue :: Name
   } deriving (Eq, Show)
 
-
 -- | <https://facebook.github.io/graphql/#ListType>
 newtype ListType = ListType
   { listTypeValue :: Type
   } deriving (Eq, Show)
-
 
 -- | <https://facebook.github.io/graphql/#NonNullType>
 data NonNullType
@@ -89,12 +77,10 @@ data NonNullType
   | NonNullTypeList ListType
   deriving (Eq, Show)
 
-
 -- | <https://facebook.github.io/graphql/#DefaultValue>
 newtype DefaultValue = DefaultValue
   { defaultValueValue :: Value
   } deriving (Eq, Show)
-
 
 -- | <https://facebook.github.io/graphql/#Value>
 data Value
@@ -109,19 +95,16 @@ data Value
   | ValueObject [ObjectField]
   deriving (Eq, Show)
 
-
 -- | <https://facebook.github.io/graphql/#ObjectField>
 data ObjectField = ObjectField
   { objectFieldName :: Name
   , objectFieldValue :: Value
   } deriving (Eq, Show)
 
-
 -- | <https://facebook.github.io/graphql/#Directives>
 newtype Directives = Directives
   { directivesValue :: NonEmpty Directive
   } deriving (Eq, Show)
-
 
 -- | <https://facebook.github.io/graphql/#Directive>
 data Directive = Directive
@@ -129,12 +112,10 @@ data Directive = Directive
   , directiveArguments :: Maybe Arguments
   } deriving (Eq, Show)
 
-
 -- | <https://facebook.github.io/graphql/#Arguments>
 newtype Arguments = Arguments
   { argumentsValue :: [Argument]
   } deriving (Eq, Show)
-
 
 -- | <https://facebook.github.io/graphql/#Argument>
 data Argument = Argument
@@ -142,12 +123,10 @@ data Argument = Argument
   , argumentValue :: Value
   } deriving (Eq, Show)
 
-
 -- | <https://facebook.github.io/graphql/#SelectionSet>
 newtype SelectionSet = SelectionSet
   { selectionSetValue :: [Selection]
   } deriving (Eq, Show)
-
 
 -- | <https://facebook.github.io/graphql/#Selection>
 data Selection
@@ -155,7 +134,6 @@ data Selection
   | SelectionFragmentSpread FragmentSpread
   | SelectionInlineFragment InlineFragment
   deriving (Eq, Show)
-
 
 -- | <https://facebook.github.io/graphql/#Field>
 data Field = Field
@@ -166,12 +144,10 @@ data Field = Field
   , fieldSelectionSet :: Maybe SelectionSet
   } deriving (Eq, Show)
 
-
 -- | <https://facebook.github.io/graphql/#Alias>
 newtype Alias = Alias
   { aliasValue :: Name
   } deriving (Eq, Show)
-
 
 -- | <https://facebook.github.io/graphql/#FragmentSpread>
 data FragmentSpread = FragmentSpread
@@ -179,12 +155,10 @@ data FragmentSpread = FragmentSpread
   , fragmentSpreadDirectives :: Maybe Directives
   } deriving (Eq, Show)
 
-
 -- | <https://facebook.github.io/graphql/#FragmentName>
 newtype FragmentName = FragmentName
   { fragmentNameValue :: Name
   } deriving (Eq, Show)
-
 
 -- | <https://facebook.github.io/graphql/#InlineFragment>
 data InlineFragment = InlineFragment
@@ -193,12 +167,10 @@ data InlineFragment = InlineFragment
   , inlineFragmentSelectionSet :: SelectionSet
   } deriving (Eq, Show)
 
-
 -- | <https://facebook.github.io/graphql/#TypeCondition>
 newtype TypeCondition = TypeCondition
   { typeConditionValue :: NamedType
   } deriving (Eq, Show)
-
 
 -- | <https://facebook.github.io/graphql/#FragmentDefinition>
 data FragmentDefinition = FragmentDefinition
@@ -208,7 +180,6 @@ data FragmentDefinition = FragmentDefinition
   , fragmentSelectionSet :: SelectionSet
   } deriving (Eq, Show)
 
-
 data TypeSystemDefinition
   = TypeSystemDefinitionSchema SchemaDefinition
   | TypeSystemDefinitionType TypeDefinition
@@ -216,23 +187,19 @@ data TypeSystemDefinition
   | TypeSystemDefinitionDirective DirectiveDefinition
   deriving (Eq, Show)
 
-
 data SchemaDefinition = SchemaDefinition
   { schemaDefinitionDirectives :: Maybe Directives
   , schemaDefinitionOperationTypes :: OperationTypeDefinitions
   } deriving (Eq, Show)
 
-
 newtype OperationTypeDefinitions = OperationTypeDefinitions
   { operationTypeDefinitionsValue :: [OperationTypeDefinition]
   } deriving (Eq, Show)
-
 
 data OperationTypeDefinition = OperationTypeDefinition
   { operationTypeDefinitionOperation :: OperationType
   , operationTypeDefinitionType :: NamedType
   } deriving (Eq, Show)
-
 
 data TypeDefinition
   = TypeDefinitionScalar ScalarTypeDefinition
@@ -243,12 +210,10 @@ data TypeDefinition
   | TypeDefinitionInputObject InputObjectTypeDefinition
   deriving (Eq, Show)
 
-
 data ScalarTypeDefinition = ScalarTypeDefinition
   { scalarTypeDefinitionName :: Name
   , scalarTypeDefinitionDirectives :: Maybe Directives
   } deriving (Eq, Show)
-
 
 data ObjectTypeDefinition = ObjectTypeDefinition
   { objectTypeDefinitionName :: Name
@@ -257,16 +222,13 @@ data ObjectTypeDefinition = ObjectTypeDefinition
   , objectTypeDefinitionFields :: FieldDefinitions
   } deriving (Eq, Show)
 
-
 newtype Interfaces = Interfaces
   { interfacesValue :: NonEmpty NamedType
   } deriving (Eq, Show)
 
-
 newtype FieldDefinitions = FieldDefinitions
   { fieldDefinitionsValue :: [FieldDefinition]
   } deriving (Eq, Show)
-
 
 data FieldDefinition = FieldDefinition
   { fieldDefinitionName :: Name
@@ -275,11 +237,9 @@ data FieldDefinition = FieldDefinition
   , fieldDefinitionDirectives :: Maybe Directives
   } deriving (Eq, Show)
 
-
 newtype InputValueDefinitions = InputValueDefinitions
   { inputValueDefinitionsValue :: [InputValueDefinition]
   } deriving (Eq, Show)
-
 
 data InputValueDefinition = InputValueDefinition
   { inputValueDefinitionName :: Name
@@ -288,13 +248,11 @@ data InputValueDefinition = InputValueDefinition
   , inputValueDefinitionDirectives :: Maybe Directives
   } deriving (Eq, Show)
 
-
 data InterfaceTypeDefinition = InterfaceTypeDefinition
   { interfaceTypeDefinitionName :: Name
   , interfaceTypeDefinitionDirectives :: Maybe Directives
   , interfaceTypeDefinitionFields :: FieldDefinitions
   } deriving (Eq, Show)
-
 
 data UnionTypeDefinition = UnionTypeDefinition
   { unionTypeDefinitionName :: Name
@@ -302,11 +260,9 @@ data UnionTypeDefinition = UnionTypeDefinition
   , unionTypeDefinitionTypes :: UnionTypes
   } deriving (Eq, Show)
 
-
 newtype UnionTypes = UnionTypes
   { unionTypesValue :: NonEmpty NamedType
   } deriving (Eq, Show)
-
 
 data EnumTypeDefinition = EnumTypeDefinition
   { enumTypeDefinitionName :: Name
@@ -314,17 +270,14 @@ data EnumTypeDefinition = EnumTypeDefinition
   , enumTypeDefinitionValues :: EnumValues
   } deriving (Eq, Show)
 
-
 newtype EnumValues = EnumValues
   { enumValuesValue :: [EnumValueDefinition]
   } deriving (Eq, Show)
-
 
 data EnumValueDefinition = EnumValueDefinition
   { enumValueDefinitionName :: Name
   , enumValueDefinitionDirectives :: Maybe Directives
   } deriving (Eq, Show)
-
 
 data InputObjectTypeDefinition = InputObjectTypeDefinition
   { inputObjectTypeDefinitionName :: Name
@@ -332,23 +285,19 @@ data InputObjectTypeDefinition = InputObjectTypeDefinition
   , inputObjectTypeDefinitionFields :: InputFieldDefinitions
   } deriving (Eq, Show)
 
-
 newtype InputFieldDefinitions = InputFieldDefinitions
   { inputFieldDefinitionsValue :: [InputValueDefinition]
   } deriving (Eq, Show)
 
-
 newtype TypeExtensionDefinition = TypeExtensionDefinition
   { typeExtensionDefinitionValue :: ObjectTypeDefinition
   } deriving (Eq, Show)
-
 
 data DirectiveDefinition = DirectiveDefinition
   { directiveDefinitionName :: Name
   , directiveDefinitionArguments :: Maybe InputValueDefinitions
   , directiveDefinitionLocations :: DirectiveLocations
   } deriving (Eq, Show)
-
 
 newtype DirectiveLocations = DirectiveLocations
   { directiveLocationsValue :: NonEmpty Name

--- a/library/Grotesque/Parser.hs
+++ b/library/Grotesque/Parser.hs
@@ -1,7 +1,11 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE RecordWildCards #-}
+
 module Grotesque.Parser where
 
 import Grotesque.Language
 
+import Data.List.NonEmpty (NonEmpty)
 import Data.Scientific (Scientific)
 import Data.Text (Text)
 import Text.Megaparsec.Text (Parser)
@@ -13,115 +17,82 @@ import qualified Text.Megaparsec as M
 import qualified Text.Megaparsec.Lexer as Lexer
 import qualified Text.Read as Read
 
-
 getDocument :: Parser Document
 getDocument = do
   _ <- getSpace
-  value <- M.many getDefinition
+  documentValue <- M.many getDefinition
   M.eof
-  pure Document
-    { documentValue = value
-    }
-
+  pure Document {..}
 
 getDefinition :: Parser Definition
-getDefinition = M.choice
-  [ fmap DefinitionOperation getOperationDefinition
-  , fmap DefinitionFragment getFragmentDefinition
-  , fmap DefinitionTypeSystem getTypeSystemDefinition
-  ]
-
+getDefinition =
+  M.choice
+    [ fmap DefinitionOperation getOperationDefinition
+    , fmap DefinitionFragment getFragmentDefinition
+    , fmap DefinitionTypeSystem getTypeSystemDefinition
+    ]
 
 getOperationDefinition :: Parser OperationDefinition
-getOperationDefinition = M.choice
-  [ getLongOperationDefinition
-  , getShortOperationDefinition
-  ]
-
+getOperationDefinition =
+  M.choice [getLongOperationDefinition, getShortOperationDefinition]
 
 getLongOperationDefinition :: Parser OperationDefinition
 getLongOperationDefinition = do
-  operationType <- getOperationType
-  name <- M.optional (M.try getName)
-  variableDefinitions <- M.optional (M.try getVariableDefinitions)
-  directives <- M.optional (M.try getDirectives)
-  selectionSet <- getSelectionSet
-  pure OperationDefinition
-    { operationDefinitionOperationType = operationType
-    , operationDefinitionName = name
-    , operationDefinitionVariableDefinitions = variableDefinitions
-    , operationDefinitionDirectives = directives
-    , operationDefinitionSelectionSet = selectionSet
-    }
-
+  operationDefinitionOperationType <- getOperationType
+  operationDefinitionName <- M.optional (M.try getName)
+  operationDefinitionVariableDefinitions <-
+    M.optional (M.try getVariableDefinitions)
+  operationDefinitionDirectives <- M.optional (M.try getDirectives)
+  operationDefinitionSelectionSet <- getSelectionSet
+  pure OperationDefinition {..}
 
 getOperationType :: Parser OperationType
-getOperationType = M.choice
-  [ fmap (const OperationTypeQuery) (getSymbol "query")
-  , fmap (const OperationTypeMutation) (getSymbol "mutation")
-  , fmap (const OperationTypeSubscription) (getSymbol "subscription")
-  ]
-
+getOperationType =
+  M.choice
+    [ fmap (const OperationTypeQuery) (getSymbol "query")
+    , fmap (const OperationTypeMutation) (getSymbol "mutation")
+    , fmap (const OperationTypeSubscription) (getSymbol "subscription")
+    ]
 
 getVariableDefinitions :: Parser VariableDefinitions
-getVariableDefinitions = getInParentheses (do
-  value <- M.many getVariableDefinition
-  pure VariableDefinitions
-    { variableDefinitionsValue = value
-    })
-
+getVariableDefinitions = do
+  variableDefinitionsValue <- getInParentheses (M.many getVariableDefinition)
+  pure VariableDefinitions {..}
 
 getInParentheses :: Parser a -> Parser a
 getInParentheses = M.between (getSymbol "(") (getSymbol ")")
 
-
 getVariableDefinition :: Parser VariableDefinition
 getVariableDefinition = do
-  variable <- getVariable
+  variableDefinitionVariable <- getVariable
   _ <- getColon
-  type_ <- getType
-  defaultValue <- M.optional getDefaultValue
-  pure VariableDefinition
-    { variableDefinitionVariable = variable
-    , variableDefinitionType = type_
-    , variableDefinitionDefaultValue = defaultValue
-    }
-
+  variableDefinitionType <- getType
+  variableDefinitionDefaultValue <- M.optional getDefaultValue
+  pure VariableDefinition {..}
 
 getType :: Parser Type
-getType = M.choice
-  [ fmap TypeNonNull (M.try getNonNullType)
-  , fmap TypeNamed getNamedType
-  , fmap TypeList getListType
-  ]
-
+getType =
+  M.choice
+    [ fmap TypeNonNull (M.try getNonNullType)
+    , fmap TypeNamed getNamedType
+    , fmap TypeList getListType
+    ]
 
 getNamedType :: Parser NamedType
 getNamedType = do
-  value <- getName
-  pure NamedType
-    { namedTypeValue = value
-    }
-
+  namedTypeValue <- getName
+  pure NamedType {..}
 
 getListType :: Parser ListType
-getListType = getInBrackets (do
-  value <- getType
-  pure ListType
-    { listTypeValue = value
-    })
-
+getListType = do
+  listTypeValue <- getInBrackets getType
+  pure ListType {..}
 
 getInBrackets :: Parser a -> Parser a
 getInBrackets = M.between (getSymbol "[") (getSymbol "]")
 
-
 getNonNullType :: Parser NonNullType
-getNonNullType = getLexeme (M.choice
-  [ getNonNullNamedType
-  , getNonNullListType
-  ])
-
+getNonNullType = getLexeme (M.choice [getNonNullNamedType, getNonNullListType])
 
 getNonNullNamedType :: Parser NonNullType
 getNonNullNamedType = do
@@ -129,10 +100,8 @@ getNonNullNamedType = do
   _ <- getExclamationPoint
   pure (NonNullTypeNamed value)
 
-
 getExclamationPoint :: Parser Char
 getExclamationPoint = M.char '!'
-
 
 getNonNullListType :: Parser NonNullType
 getNonNullListType = do
@@ -140,212 +109,164 @@ getNonNullListType = do
   _ <- getExclamationPoint
   pure (NonNullTypeList value)
 
-
 getDefaultValue :: Parser DefaultValue
 getDefaultValue = do
   _ <- getSymbol "="
-  value <- getValue
-  pure DefaultValue
-    { defaultValueValue = value
-    }
-
+  defaultValueValue <- getValue
+  pure DefaultValue {..}
 
 getDirectives :: Parser Directives
 getDirectives = do
-  list <- M.some getDirective
-  case NonEmpty.nonEmpty list of
-    Nothing -> fail "impossible"
-    Just value -> pure Directives
-      { directivesValue = value
-      }
+  directivesValue <- getNonEmpty getDirective getDirective
+  pure Directives {..}
 
+getNonEmpty :: Parser a -> Parser a -> Parser (NonEmpty a)
+getNonEmpty getFirst getRest = do
+  first <- getFirst
+  rest <- M.many getRest
+  pure (first NonEmpty.:| rest)
 
 getDirective :: Parser Directive
 getDirective = do
   _ <- getSymbol "@"
-  name <- getName
-  arguments <- M.optional getArguments
-  pure Directive
-    { directiveName = name
-    , directiveArguments = arguments
-    }
-
+  directiveName <- getName
+  directiveArguments <- M.optional getArguments
+  pure Directive {..}
 
 getShortOperationDefinition :: Parser OperationDefinition
 getShortOperationDefinition = do
-  selectionSet <- getSelectionSet
-  pure OperationDefinition
-    { operationDefinitionOperationType = OperationTypeQuery
-    , operationDefinitionName = Nothing
-    , operationDefinitionVariableDefinitions = Nothing
-    , operationDefinitionDirectives = Nothing
-    , operationDefinitionSelectionSet = selectionSet
-    }
-
+  let operationDefinitionOperationType = OperationTypeQuery
+      operationDefinitionName = Nothing
+      operationDefinitionVariableDefinitions = Nothing
+      operationDefinitionDirectives = Nothing
+  operationDefinitionSelectionSet <- getSelectionSet
+  pure OperationDefinition {..}
 
 getSelectionSet :: Parser SelectionSet
-getSelectionSet = getInBraces (do
-  value <- M.many getSelection
-  pure SelectionSet
-    { selectionSetValue = value
-    })
-
+getSelectionSet = do
+  selectionSetValue <- getInBraces (M.many getSelection)
+  pure SelectionSet {..}
 
 getInBraces :: Parser a -> Parser a
 getInBraces = M.between (getSymbol "{") (getSymbol "}")
 
-
 getSelection :: Parser Selection
-getSelection = M.choice
-  [ fmap SelectionField getField
-  , fmap SelectionFragmentSpread (M.try getFragmentSpread)
-  , fmap SelectionInlineFragment getInlineFragment
-  ]
-
+getSelection =
+  M.choice
+    [ fmap SelectionField getField
+    , fmap SelectionFragmentSpread (M.try getFragmentSpread)
+    , fmap SelectionInlineFragment getInlineFragment
+    ]
 
 getField :: Parser Field
 getField = do
-  alias <- M.optional (M.try getAlias)
-  name <- getName
-  arguments <- M.optional (M.try getArguments)
-  directives <- M.optional (M.try getDirectives)
-  selectionSet <- M.optional (M.try getSelectionSet)
-  pure Field
-    { fieldAlias = alias
-    , fieldName = name
-    , fieldArguments = arguments
-    , fieldDirectives = directives
-    , fieldSelectionSet = selectionSet
-    }
-
+  fieldAlias <- M.optional (M.try getAlias)
+  fieldName <- getName
+  fieldArguments <- M.optional (M.try getArguments)
+  fieldDirectives <- M.optional (M.try getDirectives)
+  fieldSelectionSet <- M.optional (M.try getSelectionSet)
+  pure Field {..}
 
 getAlias :: Parser Alias
 getAlias = do
-  value <- getName
+  aliasValue <- getName
   _ <- getColon
-  pure Alias
-    { aliasValue = value
-    }
-
+  pure Alias {..}
 
 getColon :: Parser String
 getColon = getSymbol ":"
 
-
 getName :: Parser Name
-getName = getLexeme (do
-  let
-    underscore = ['_']
-    uppers = ['A' .. 'Z']
-    lowers = ['a' .. 'z']
-    digits = ['0' .. '9']
-  first <- M.oneOf (concat [underscore, uppers, lowers])
-  rest <- M.many (M.oneOf (concat [underscore, digits, uppers, lowers]))
-  pure Name
-    { nameValue = Text.pack (first : rest)
-    })
+getName = do
+  value <-
+    getLexeme (getNonEmpty (M.oneOf nameFirstChars) (M.oneOf nameRestChars))
+  pure Name {nameValue = Text.pack (NonEmpty.toList value)}
 
+nameFirstChars :: String
+nameFirstChars = concat ["_", ['A' .. 'Z'], ['a' .. 'z']]
+
+nameRestChars :: String
+nameRestChars = nameFirstChars ++ ['0' .. '9']
 
 getArguments :: Parser Arguments
-getArguments = getInParentheses (do
-  value <- M.many getArgument
-  pure Arguments
-    { argumentsValue = value
-    })
-
+getArguments =
+  getInParentheses
+    (do argumentsValue <- M.many getArgument
+        pure Arguments {..})
 
 getArgument :: Parser Argument
 getArgument = do
-  name <- getName
+  argumentName <- getName
   _ <- getColon
-  value <- getValue
-  pure Argument
-    { argumentName = name
-    , argumentValue = value
-    }
-
+  argumentValue <- getValue
+  pure Argument {..}
 
 getValue :: Parser Value
-getValue = M.choice
-  [ fmap ValueVariable getVariable
-  , fmap ValueFloat (M.try getFloat)
-  , fmap ValueInt getInt
-  , fmap ValueString getString
-  , fmap ValueBoolean getBoolean
-  , fmap (const ValueNull) getNull
-  , fmap ValueEnum getEnum
-  , fmap ValueList getList
-  , fmap ValueObject getObject
-  ]
-
+getValue =
+  M.choice
+    [ fmap ValueVariable getVariable
+    , fmap ValueFloat (M.try getFloat)
+    , fmap ValueInt getInt
+    , fmap ValueString getString
+    , fmap ValueBoolean getBoolean
+    , fmap (const ValueNull) getNull
+    , fmap ValueEnum getEnum
+    , fmap ValueList getList
+    , fmap ValueObject getObject
+    ]
 
 getVariable :: Parser Variable
 getVariable = do
   _ <- getSymbol "$"
-  value <- getName
-  pure Variable
-    { variableValue = value
-    }
-
+  variableValue <- getName
+  pure Variable {..}
 
 getInt :: Parser Integer
-getInt = getLexeme (do
-  integerPart <- getIntegerPart
-  case Read.readMaybe integerPart of
-    Nothing -> fail "impossible"
-    Just int -> pure int)
+getInt = getLexeme (getAndRead getIntegerPart)
 
+getAndRead :: Read a => Parser String -> Parser a
+getAndRead get = do
+  string <- get
+  case Read.readMaybe string of
+    Nothing -> fail "getAndRead: no parse"
+    Just value -> pure value
 
 getIntegerPart :: Parser String
-getIntegerPart = M.choice
-  [ M.try getZero
-  , getNonZero
-  ]
-
+getIntegerPart = M.choice [M.try getZero, getNonZero]
 
 getZero :: Parser String
 getZero = do
-  maybeNegativeSign <- M.optional getNegativeSign
+  negativeSign <- getNegativeSign
   zero <- M.char '0'
-  case maybeNegativeSign of
-    Nothing -> pure ([zero])
-    Just negativeSign -> pure (negativeSign : [zero])
-
+  pure [negativeSign, zero]
 
 getNegativeSign :: Parser Char
-getNegativeSign = M.char '-'
-
+getNegativeSign = M.choice [M.char '-', pure ' ']
 
 getNonZero :: Parser String
 getNonZero = do
-  maybeNegativeSign <- M.optional getNegativeSign
-  first <- getNonZeroDigit
-  rest <- M.many M.digitChar
-  case maybeNegativeSign of
-    Nothing -> pure (first : rest)
-    Just negativeSign -> pure (negativeSign : first : rest)
-
+  negativeSign <- getNegativeSign
+  nonZero <- getNonEmpty getNonZeroDigit M.digitChar
+  pure (negativeSign : NonEmpty.toList nonZero)
 
 getNonZeroDigit :: Parser Char
 getNonZeroDigit = M.oneOf ['1' .. '9']
 
-
 getFloat :: Parser Scientific
-getFloat = getLexeme (M.choice
-  [ M.try getFractionalExponentFloat
-  , M.try getFractionalFloat
-  , getExponentFloat
-  ])
-
+getFloat =
+  getLexeme
+    (M.choice
+       [ M.try getFractionalExponentFloat
+       , M.try getFractionalFloat
+       , getExponentFloat
+       ])
 
 getFractionalFloat :: Parser Scientific
-getFractionalFloat = do
-  integerPart <- getIntegerPart
-  fractionalPart <- getFractionalPart
-  case Read.readMaybe (integerPart ++ fractionalPart) of
-    Nothing -> fail "impossible"
-    Just float -> pure float
-
+getFractionalFloat =
+  getAndRead
+    (do integerPart <- getIntegerPart
+        fractionalPart <- getFractionalPart
+        pure (integerPart ++ fractionalPart))
 
 getFractionalPart :: Parser String
 getFractionalPart = do
@@ -353,100 +274,106 @@ getFractionalPart = do
   digits <- M.some M.digitChar
   pure (decimalPoint : digits)
 
-
 getDecimalPoint :: Parser Char
 getDecimalPoint = M.char '.'
 
-
 getExponentFloat :: Parser Scientific
-getExponentFloat = do
-  integerPart <- getIntegerPart
-  exponentPart <- getExponentPart
-  case Read.readMaybe (integerPart ++ exponentPart) of
-    Nothing -> fail "impossible"
-    Just float -> pure float
-
+getExponentFloat =
+  getAndRead
+    (do integerPart <- getIntegerPart
+        exponentPart <- getExponentPart
+        pure (integerPart ++ exponentPart))
 
 getExponentPart :: Parser String
 getExponentPart = do
   exponentIndicator <- getExponentIndicator
-  maybeSign <- M.optional getSign
+  sign <- getSign
   digits <- M.some M.digitChar
-  case maybeSign of
-    Nothing -> pure (exponentIndicator : digits)
-    Just sign -> pure (exponentIndicator : sign : digits)
-
+  pure (exponentIndicator : sign : digits)
 
 getExponentIndicator :: Parser Char
 getExponentIndicator = M.char' 'e'
 
-
 getSign :: Parser Char
-getSign = M.oneOf ['+', '-']
-
+getSign = M.choice [M.oneOf "+-", pure '+']
 
 getFractionalExponentFloat :: Parser Scientific
-getFractionalExponentFloat = do
-  integerPart <- getIntegerPart
-  fractionalPart <- getFractionalPart
-  exponentPart <- getExponentPart
-  case Read.readMaybe (integerPart ++ fractionalPart ++ exponentPart) of
-    Nothing -> fail "impossible"
-    Just float -> pure float
-
+getFractionalExponentFloat =
+  getAndRead
+    (do integerPart <- getIntegerPart
+        fractionalPart <- getFractionalPart
+        exponentPart <- getExponentPart
+        pure (concat [integerPart, fractionalPart, exponentPart]))
 
 getString :: Parser Text
-getString = getLexeme (do
-  _ <- getQuote
-  characters <- M.many getCharacter
-  _ <- getQuote
-  pure (Text.pack characters))
+getString = getLexeme (getInQuotes (getText (M.many getCharacter)))
 
+getInQuotes :: Parser a -> Parser a
+getInQuotes get = do
+  _ <- getQuote
+  value <- get
+  _ <- getQuote
+  pure value
 
 getQuote :: Parser Char
 getQuote = M.char '"'
 
+getText :: Parser String -> Parser Text
+getText get = do
+  value <- get
+  pure (Text.pack value)
 
 getCharacter :: Parser Char
-getCharacter = M.choice
-  [ getStringCharacter
-  , M.try getSurrogateCharacter
-  , M.try getUnicodeCharacter
-  , getEscapedCharacter
-  ]
-
+getCharacter =
+  M.choice
+    [ getStringCharacter
+    , M.try getSurrogateCharacter
+    , M.try getUnicodeCharacter
+    , getEscapedCharacter
+    ]
 
 getStringCharacter :: Parser Char
-getStringCharacter = M.oneOf (concat
-  [ ['\x0009']
-  , ['\x0020' .. '\x0021']
-  , ['\x0023' .. '\x005b']
-  , ['\x005d' .. '\xffff']
-  ])
-
+getStringCharacter =
+  M.oneOf
+    (concat
+       [ "\x0009"
+       , ['\x0020' .. '\x0021']
+       , ['\x0023' .. '\x005b']
+       , ['\x005d' .. '\xffff']
+       ])
 
 getSurrogateCharacter :: Parser Char
 getSurrogateCharacter = do
-  hd <- getUnicodeEscape
-  ld <- getUnicodeEscape
-  case Read.readMaybe ("(0x" ++ hd ++ ", 0x" ++ ld ++ ")") of
-    Nothing -> fail "impossible"
-    Just (h, l) -> if h < 0xd800 || h > 0xdbff || l < 0xdc00 || l > 0xdfff
-      then fail "invalid surrogate"
-      else let
-        n = 0x010000 + (Bits.shiftL (h Bits..&. 0x0003ff) 10) + (l Bits..&. 0x0003ff)
-        in if n <= fromEnum (maxBound :: Char)
-          then pure (toEnum n)
-          else fail "impossible"
+  (h, l) <-
+    getAndRead
+      (do h <- getUnicodeEscape
+          l <- getUnicodeEscape
+          pure (concat ["(0x", h, ", 0x", l, ")"]))
+  let n = combineSurrogates h l
+  if not (validHighSurrogate h) || not (validLowSurrogate l)
+    then fail "invalid surrogate"
+    else if not (validChar n)
+           then fail "impossible"
+           else pure (toEnum n)
 
+validHighSurrogate :: Int -> Bool
+validHighSurrogate h = 0xd800 <= h && h <= 0xdbff
+
+validLowSurrogate :: Int -> Bool
+validLowSurrogate l = 0xdc00 <= l && l <= 0xdfff
+
+combineSurrogates :: Int -> Int -> Int
+combineSurrogates h l =
+  0x010000 + Bits.shiftL (h Bits..&. 0x0003ff) 10 + (l Bits..&. 0x0003ff)
+
+validChar :: Int -> Bool
+validChar n = n <= fromEnum (maxBound :: Char)
 
 getUnicodeCharacter :: Parser Char
-getUnicodeCharacter = do
-  digits <- getUnicodeEscape
-  case Read.readMaybe ("\'\\x" ++ digits ++ "\'") of
-    Nothing -> fail "impossible"
-    Just character -> pure character
-
+getUnicodeCharacter =
+  getAndRead
+    (do digits <- getUnicodeEscape
+        pure (concat ["'\\x", digits, "'"]))
 
 getUnicodeEscape :: Parser String
 getUnicodeEscape = do
@@ -454,11 +381,10 @@ getUnicodeEscape = do
   _ <- M.char 'u'
   M.count 4 M.hexDigitChar
 
-
 getEscapedCharacter :: Parser Char
 getEscapedCharacter = do
   _ <- getBackslash
-  escape <- M.oneOf ['"', '\\', '/', 'b', 'f', 'n', 'r', 't']
+  escape <- M.oneOf "\"\\/bfnrt"
   case escape of
     '"' -> pure '\x0022'
     '\\' -> pure '\x005c'
@@ -470,383 +396,260 @@ getEscapedCharacter = do
     't' -> pure '\x0009'
     _ -> fail "impossible"
 
-
 getBackslash :: Parser Char
 getBackslash = M.char '\\'
 
-
 getBoolean :: Parser Bool
-getBoolean = M.choice
-  [ fmap (const True) getTrue
-  , fmap (const False) getFalse
-  ]
-
+getBoolean = M.choice [fmap (const True) getTrue, fmap (const False) getFalse]
 
 getTrue :: Parser String
 getTrue = getSymbol "true"
 
-
 getFalse :: Parser String
 getFalse = getSymbol "false"
-
 
 getNull :: Parser String
 getNull = getSymbol "null"
 
-
 getEnum :: Parser Name
 getEnum = getName
-
 
 getList :: Parser [Value]
 getList = getInBrackets (M.many getValue)
 
-
 getObject :: Parser [ObjectField]
 getObject = getInBraces (M.many getObjectField)
 
-
 getObjectField :: Parser ObjectField
 getObjectField = do
-  name <- getName
+  objectFieldName <- getName
   _ <- getColon
-  value <- getValue
-  pure ObjectField
-    { objectFieldName = name
-    , objectFieldValue = value
-    }
-
+  objectFieldValue <- getValue
+  pure ObjectField {..}
 
 getFragmentSpread :: Parser FragmentSpread
 getFragmentSpread = do
   _ <- getEllipsis
-  name <- getFragmentName
-  directives <- M.optional getDirectives
-  pure FragmentSpread
-    { fragmentSpreadName = name
-    , fragmentSpreadDirectives = directives
-    }
-
+  fragmentSpreadName <- getFragmentName
+  fragmentSpreadDirectives <- M.optional getDirectives
+  pure FragmentSpread {..}
 
 getEllipsis :: Parser String
 getEllipsis = getSymbol "..."
 
-
 getFragmentName :: Parser FragmentName
 getFragmentName = do
-  value <- getName
-  case Text.unpack (nameValue value) of
+  fragmentNameValue <- getName
+  case Text.unpack (nameValue fragmentNameValue) of
     "on" -> fail "invalid fragment name"
-    _ -> pure FragmentName
-      { fragmentNameValue = value
-      }
-
+    _ -> pure FragmentName {..}
 
 getInlineFragment :: Parser InlineFragment
 getInlineFragment = do
   _ <- getEllipsis
-  typeCondition <- M.optional getTypeCondition
-  directives <- M.optional getDirectives
-  selectionSet <- getSelectionSet
-  pure InlineFragment
-    { inlineFragmentTypeCondition = typeCondition
-    , inlineFragmentDirectives = directives
-    , inlineFragmentSelectionSet = selectionSet
-    }
-
+  inlineFragmentTypeCondition <- M.optional getTypeCondition
+  inlineFragmentDirectives <- M.optional getDirectives
+  inlineFragmentSelectionSet <- getSelectionSet
+  pure InlineFragment {..}
 
 getTypeCondition :: Parser TypeCondition
 getTypeCondition = do
   _ <- getSymbol "on"
-  value <- getNamedType
-  pure TypeCondition
-    { typeConditionValue = value
-    }
-
+  typeConditionValue <- getNamedType
+  pure TypeCondition {..}
 
 getSymbol :: String -> Parser String
 getSymbol = Lexer.symbol getSpace
 
-
 getLexeme :: Parser a -> Parser a
 getLexeme = Lexer.lexeme getSpace
 
-
 getSpace :: Parser ()
-getSpace = Lexer.space
-  (do
-    _ <- M.oneOf ['\xfeff', '\x0009', '\x0020', '\x000a', '\x000d', ',']
-    pure ())
-  (Lexer.skipLineComment "#")
-  (fail "no block comments")
-
+getSpace =
+  Lexer.space
+    (do _ <- M.oneOf "\x0009\x000a\x000d\x0020,\xfeff"
+        pure ())
+    (Lexer.skipLineComment "#")
+    (fail "no block comments")
 
 getFragmentDefinition :: Parser FragmentDefinition
 getFragmentDefinition = do
   _ <- getSymbol "fragment"
-  name <- getFragmentName
-  typeCondition <- getTypeCondition
-  directives <- M.optional getDirectives
-  selectionSet <- getSelectionSet
-  pure FragmentDefinition
-    { fragmentName = name
-    , fragmentTypeCondition = typeCondition
-    , fragmentDirectives = directives
-    , fragmentSelectionSet = selectionSet
-    }
-
+  fragmentName <- getFragmentName
+  fragmentTypeCondition <- getTypeCondition
+  fragmentDirectives <- M.optional getDirectives
+  fragmentSelectionSet <- getSelectionSet
+  pure FragmentDefinition {..}
 
 getTypeSystemDefinition :: Parser TypeSystemDefinition
-getTypeSystemDefinition = M.choice
-  [ fmap TypeSystemDefinitionSchema getSchemaDefinition
-  , fmap TypeSystemDefinitionType getTypeDefinition
-  , fmap TypeSystemDefinitionTypeExtension getTypeExtensionDefinition
-  , fmap TypeSystemDefinitionDirective getDirectiveDefinition
-  ]
-
+getTypeSystemDefinition =
+  M.choice
+    [ fmap TypeSystemDefinitionSchema getSchemaDefinition
+    , fmap TypeSystemDefinitionType getTypeDefinition
+    , fmap TypeSystemDefinitionTypeExtension getTypeExtensionDefinition
+    , fmap TypeSystemDefinitionDirective getDirectiveDefinition
+    ]
 
 getSchemaDefinition :: Parser SchemaDefinition
 getSchemaDefinition = do
   _ <- getSymbol "schema"
-  directives <- M.optional getDirectives
-  operationTypeDefinitions <- getOperationTypeDefintions
-  pure SchemaDefinition
-    { schemaDefinitionDirectives = directives
-    , schemaDefinitionOperationTypes = operationTypeDefinitions
-    }
-
+  schemaDefinitionDirectives <- M.optional getDirectives
+  schemaDefinitionOperationTypes <- getOperationTypeDefintions
+  pure SchemaDefinition {..}
 
 getOperationTypeDefintions :: Parser OperationTypeDefinitions
-getOperationTypeDefintions = getInBraces (do
-  value <- M.many getOperationTypeDefintion
-  pure OperationTypeDefinitions
-    { operationTypeDefinitionsValue = value
-    })
-
+getOperationTypeDefintions = do
+  operationTypeDefinitionsValue <-
+    getInBraces (M.many getOperationTypeDefintion)
+  pure OperationTypeDefinitions {..}
 
 getOperationTypeDefintion :: Parser OperationTypeDefinition
 getOperationTypeDefintion = do
-  operation <- getOperationType
+  operationTypeDefinitionOperation <- getOperationType
   _ <- getColon
-  type_ <- getNamedType
-  pure OperationTypeDefinition
-    { operationTypeDefinitionOperation = operation
-    , operationTypeDefinitionType = type_
-    }
-
+  operationTypeDefinitionType <- getNamedType
+  pure OperationTypeDefinition {..}
 
 getTypeDefinition :: Parser TypeDefinition
-getTypeDefinition = M.choice
-  [ fmap TypeDefinitionScalar getScalarTypeDefinition
-  , fmap TypeDefinitionObject getObjectTypeDefinition
-  , fmap TypeDefinitionInterface getInterfaceTypeDefinition
-  , fmap TypeDefinitionUnion getUnionTypeDefinition
-  , fmap TypeDefinitionEnum getEnumTypeDefinition
-  , fmap TypeDefinitionInputObject getInputObjectTypeDefinition
-  ]
-
+getTypeDefinition =
+  M.choice
+    [ fmap TypeDefinitionScalar getScalarTypeDefinition
+    , fmap TypeDefinitionObject getObjectTypeDefinition
+    , fmap TypeDefinitionInterface getInterfaceTypeDefinition
+    , fmap TypeDefinitionUnion getUnionTypeDefinition
+    , fmap TypeDefinitionEnum getEnumTypeDefinition
+    , fmap TypeDefinitionInputObject getInputObjectTypeDefinition
+    ]
 
 getScalarTypeDefinition :: Parser ScalarTypeDefinition
 getScalarTypeDefinition = do
   _ <- getSymbol "scalar"
-  name <- getName
-  directives <- M.optional getDirectives
-  pure ScalarTypeDefinition
-    { scalarTypeDefinitionName = name
-    , scalarTypeDefinitionDirectives = directives
-    }
-
+  scalarTypeDefinitionName <- getName
+  scalarTypeDefinitionDirectives <- M.optional getDirectives
+  pure ScalarTypeDefinition {..}
 
 getObjectTypeDefinition :: Parser ObjectTypeDefinition
 getObjectTypeDefinition = do
   _ <- getSymbol "type"
-  name <- getName
-  interfaces <- M.optional getInterfaces
-  directives <- M.optional getDirectives
-  fields <- getFieldDefinitions
-  pure ObjectTypeDefinition
-    { objectTypeDefinitionName = name
-    , objectTypeDefinitionInterfaces = interfaces
-    , objectTypeDefinitionDirectives = directives
-    , objectTypeDefinitionFields = fields
-    }
-
+  objectTypeDefinitionName <- getName
+  objectTypeDefinitionInterfaces <- M.optional getInterfaces
+  objectTypeDefinitionDirectives <- M.optional getDirectives
+  objectTypeDefinitionFields <- getFieldDefinitions
+  pure ObjectTypeDefinition {..}
 
 getInterfaces :: Parser Interfaces
 getInterfaces = do
   _ <- getSymbol "implements"
-  list <- M.some getNamedType
-  case NonEmpty.nonEmpty list of
-    Nothing -> fail "impossible"
-    Just value -> pure Interfaces
-      { interfacesValue = value
-      }
-
+  interfacesValue <- getNonEmpty getNamedType getNamedType
+  pure Interfaces {..}
 
 getFieldDefinitions :: Parser FieldDefinitions
-getFieldDefinitions = getInBraces (do
-  value <- M.many getFieldDefinition
-  pure FieldDefinitions
-    { fieldDefinitionsValue = value
-    })
-
+getFieldDefinitions = do
+  fieldDefinitionsValue <- getInBraces (M.many getFieldDefinition)
+  pure FieldDefinitions {..}
 
 getFieldDefinition :: Parser FieldDefinition
 getFieldDefinition = do
-  name <- getName
-  arguments <- M.optional getInputValueDefinitions
+  fieldDefinitionName <- getName
+  fieldDefinitionArguments <- M.optional getInputValueDefinitions
   _ <- getColon
-  type_ <- getType
-  directives <- M.optional getDirectives
-  pure FieldDefinition
-    { fieldDefinitionName = name
-    , fieldDefinitionArguments = arguments
-    , fieldDefinitionType = type_
-    , fieldDefinitionDirectives = directives
-    }
-
+  fieldDefinitionType <- getType
+  fieldDefinitionDirectives <- M.optional getDirectives
+  pure FieldDefinition {..}
 
 getInputValueDefinitions :: Parser InputValueDefinitions
-getInputValueDefinitions = getInParentheses (do
-  value <- M.many getInputValueDefinition
-  pure InputValueDefinitions
-    { inputValueDefinitionsValue = value
-    })
-
+getInputValueDefinitions = do
+  inputValueDefinitionsValue <-
+    getInParentheses (M.many getInputValueDefinition)
+  pure InputValueDefinitions {..}
 
 getInputValueDefinition :: Parser InputValueDefinition
 getInputValueDefinition = do
-  name <- getName
+  inputValueDefinitionName <- getName
   _ <- getColon
-  type_ <- getType
-  defaultValue <- M.optional getDefaultValue
-  directives <- M.optional getDirectives
-  pure InputValueDefinition
-    { inputValueDefinitionName = name
-    , inputValueDefinitionType = type_
-    , inputValueDefinitionDefaultValue = defaultValue
-    , inputValueDefinitionDirectives = directives
-    }
-
+  inputValueDefinitionType <- getType
+  inputValueDefinitionDefaultValue <- M.optional getDefaultValue
+  inputValueDefinitionDirectives <- M.optional getDirectives
+  pure InputValueDefinition {..}
 
 getInterfaceTypeDefinition :: Parser InterfaceTypeDefinition
 getInterfaceTypeDefinition = do
   _ <- getSymbol "interface"
-  name <- getName
-  directives <- M.optional getDirectives
-  fieldDefinitions <- getFieldDefinitions
-  pure InterfaceTypeDefinition
-    { interfaceTypeDefinitionName = name
-    , interfaceTypeDefinitionDirectives = directives
-    , interfaceTypeDefinitionFields = fieldDefinitions
-    }
-
+  interfaceTypeDefinitionName <- getName
+  interfaceTypeDefinitionDirectives <- M.optional getDirectives
+  interfaceTypeDefinitionFields <- getFieldDefinitions
+  pure InterfaceTypeDefinition {..}
 
 getUnionTypeDefinition :: Parser UnionTypeDefinition
 getUnionTypeDefinition = do
   _ <- getSymbol "union"
-  name <- getName
-  directives <- M.optional getDirectives
+  unionTypeDefinitionName <- getName
+  unionTypeDefinitionDirectives <- M.optional getDirectives
   _ <- getSymbol "="
-  types <- getUnionTypes
-  pure UnionTypeDefinition
-    { unionTypeDefinitionName = name
-    , unionTypeDefinitionDirectives = directives
-    , unionTypeDefinitionTypes = types
-    }
-
+  unionTypeDefinitionTypes <- getUnionTypes
+  pure UnionTypeDefinition {..}
 
 getUnionTypes :: Parser UnionTypes
 getUnionTypes = do
-  list <- M.sepBy1 getNamedType (getSymbol "|")
-  case NonEmpty.nonEmpty list of
-    Nothing -> fail "impossible"
-    Just value -> pure UnionTypes
-      { unionTypesValue = value
-      }
+  unionTypesValue <-
+    getNonEmpty getNamedType (withPrefix (getSymbol "|") getNamedType)
+  pure UnionTypes {..}
 
+withPrefix :: Parser b -> Parser a -> Parser a
+withPrefix getPrefix get = do
+  _ <- getPrefix
+  get
 
 getEnumTypeDefinition :: Parser EnumTypeDefinition
 getEnumTypeDefinition = do
   _ <- getSymbol "enum"
-  name <- getName
-  directives <- M.optional getDirectives
-  values <- getEnumValues
-  pure EnumTypeDefinition
-    { enumTypeDefinitionName = name
-    , enumTypeDefinitionDirectives = directives
-    , enumTypeDefinitionValues = values
-    }
-
+  enumTypeDefinitionName <- getName
+  enumTypeDefinitionDirectives <- M.optional getDirectives
+  enumTypeDefinitionValues <- getEnumValues
+  pure EnumTypeDefinition {..}
 
 getEnumValues :: Parser EnumValues
-getEnumValues = getInBraces (do
-  value <- M.many getEnumValueDefinition
-  pure EnumValues
-    { enumValuesValue = value
-    })
-
+getEnumValues = do
+  enumValuesValue <- getInBraces (M.many getEnumValueDefinition)
+  pure EnumValues {..}
 
 getEnumValueDefinition :: Parser EnumValueDefinition
 getEnumValueDefinition = do
-  name <- getName
-  directives <- M.optional getDirectives
-  pure EnumValueDefinition
-    { enumValueDefinitionName = name
-    , enumValueDefinitionDirectives = directives
-    }
-
+  enumValueDefinitionName <- getName
+  enumValueDefinitionDirectives <- M.optional getDirectives
+  pure EnumValueDefinition {..}
 
 getInputObjectTypeDefinition :: Parser InputObjectTypeDefinition
 getInputObjectTypeDefinition = do
   _ <- getSymbol "input"
-  name <- getName
-  directives <- M.optional getDirectives
-  fields <- getInputFieldDefinitions
-  pure InputObjectTypeDefinition
-    { inputObjectTypeDefinitionName = name
-    , inputObjectTypeDefinitionDirectives = directives
-    , inputObjectTypeDefinitionFields = fields
-    }
-
+  inputObjectTypeDefinitionName <- getName
+  inputObjectTypeDefinitionDirectives <- M.optional getDirectives
+  inputObjectTypeDefinitionFields <- getInputFieldDefinitions
+  pure InputObjectTypeDefinition {..}
 
 getInputFieldDefinitions :: Parser InputFieldDefinitions
-getInputFieldDefinitions = getInBraces (do
-  value <- M.many getInputValueDefinition
-  pure InputFieldDefinitions
-    { inputFieldDefinitionsValue = value
-    })
-
+getInputFieldDefinitions = do
+  inputFieldDefinitionsValue <- getInBraces (M.many getInputValueDefinition)
+  pure InputFieldDefinitions {..}
 
 getTypeExtensionDefinition :: Parser TypeExtensionDefinition
 getTypeExtensionDefinition = do
   _ <- getSymbol "extend"
-  value <- getObjectTypeDefinition
-  pure TypeExtensionDefinition
-    { typeExtensionDefinitionValue = value
-    }
-
+  typeExtensionDefinitionValue <- getObjectTypeDefinition
+  pure TypeExtensionDefinition {..}
 
 getDirectiveDefinition :: Parser DirectiveDefinition
 getDirectiveDefinition = do
   _ <- getSymbol "directive"
   _ <- getSymbol "@"
-  name <- getName
-  arguments <- M.optional getInputValueDefinitions
+  directiveDefinitionName <- getName
+  directiveDefinitionArguments <- M.optional getInputValueDefinitions
   _ <- getSymbol "on"
-  locations <- getDirectiveLocations
-  pure DirectiveDefinition
-    { directiveDefinitionName = name
-    , directiveDefinitionArguments = arguments
-    , directiveDefinitionLocations = locations
-    }
-
+  directiveDefinitionLocations <- getDirectiveLocations
+  pure DirectiveDefinition {..}
 
 getDirectiveLocations :: Parser DirectiveLocations
 getDirectiveLocations = do
-  list <- M.sepBy1 getName (getSymbol "|")
-  case NonEmpty.nonEmpty list of
-    Nothing -> fail "impossible"
-    Just value -> pure DirectiveLocations
-      { directiveLocationsValue = value
-      }
+  directiveLocationsValue <-
+    getNonEmpty getName (withPrefix (getSymbol "|") getName)
+  pure DirectiveLocations {..}

--- a/library/Grotesque/PrettyPrinter.hs
+++ b/library/Grotesque/PrettyPrinter.hs
@@ -21,7 +21,8 @@ import qualified Text.Printf as Printf
 
 prettyPrintDocument :: Document -> Text
 prettyPrintDocument x =
-  P.renderStrict (P.layoutPretty (P.LayoutOptions P.Unbounded) (prettyDocument x))
+  P.renderStrict
+    (P.layoutPretty (P.LayoutOptions P.Unbounded) (prettyDocument x))
 
 prettyDocument :: Document -> Doc a
 prettyDocument Document {..} = P.vsep (map prettyDefinition documentValue)

--- a/library/Grotesque/PrettyPrinter.hs
+++ b/library/Grotesque/PrettyPrinter.hs
@@ -1,9 +1,12 @@
+{-# LANGUAGE RecordWildCards #-}
+
 module Grotesque.PrettyPrinter where
 
 import Grotesque.Language
 
 import Data.Scientific (Scientific)
 import Data.Text (Text)
+import Data.Text.Lazy.Builder (Builder)
 import Data.Text.Prettyprint.Doc (Doc)
 
 import qualified Data.Bits as Bits
@@ -15,411 +18,404 @@ import qualified Data.Text.Lazy.Builder.Scientific as Scientific
 import qualified Data.Text.Prettyprint.Doc as P
 import qualified Text.Printf as Printf
 
+prettyDocument :: Document -> Doc a
+prettyDocument Document {..} = P.vsep (map prettyDefinition documentValue)
 
-prettyDocument :: Document -> Doc ()
-prettyDocument x = P.vsep (map prettyDefinition (documentValue x))
+prettyDefinition :: Definition -> Doc a
+prettyDefinition x =
+  case x of
+    DefinitionOperation y -> prettyOperationDefinition y
+    DefinitionFragment y -> prettyFragmentDefinition y
+    DefinitionTypeSystem y -> prettyTypeSystemDefinition y
 
-
-prettyDefinition :: Definition -> Doc ()
-prettyDefinition x = case x of
-  DefinitionOperation y -> prettyOperationDefinition y
-  DefinitionFragment y -> prettyFragmentDefinition y
-  DefinitionTypeSystem y -> prettyTypeSystemDefinition y
-
-
-prettyOperationDefinition :: OperationDefinition -> Doc ()
-prettyOperationDefinition x = P.sep (Maybe.catMaybes
-  [ Just (prettyOperationType (operationDefinitionOperationType x))
-  , fmap prettyName (operationDefinitionName x)
-  , fmap prettyVariableDefinitions (operationDefinitionVariableDefinitions x)
-  , fmap prettyDirectives (operationDefinitionDirectives x)
-  , Just (prettySelectionSet (operationDefinitionSelectionSet x))
-  ])
-
-
-prettyName :: Name -> Doc ()
-prettyName x = P.pretty (nameValue x)
-
-
-prettyVariableDefinitions :: VariableDefinitions -> Doc ()
-prettyVariableDefinitions x =
-  P.parens (P.sep (map prettyVariableDefinition (variableDefinitionsValue x)))
-
-
-prettyVariableDefinition :: VariableDefinition -> Doc ()
-prettyVariableDefinition x = P.sep (Maybe.catMaybes
-  [ Just (P.hcat [prettyVariable (variableDefinitionVariable x), P.pretty ":"])
-  , Just (prettyType (variableDefinitionType x))
-  , fmap prettyDefaultValue (variableDefinitionDefaultValue x)
-  ])
-
-
-prettyType :: Type -> Doc ()
-prettyType x = case x of
-  TypeNamed y -> prettyNamedType y
-  TypeList y -> prettyListType y
-  TypeNonNull y -> prettyNonNullType y
-
-
-prettyNamedType :: NamedType -> Doc ()
-prettyNamedType x = prettyName (namedTypeValue x)
-
-
-prettyListType :: ListType -> Doc ()
-prettyListType x = P.brackets (prettyType (listTypeValue x))
-
-
-prettyNonNullType :: NonNullType -> Doc ()
-prettyNonNullType x = case x of
-  NonNullTypeNamed y -> P.hcat [prettyNamedType y, P.pretty "!"]
-  NonNullTypeList y -> P.hcat [prettyListType y, P.pretty "!"]
-
-
-prettyDefaultValue :: DefaultValue -> Doc ()
-prettyDefaultValue x = P.sep [P.pretty "=", prettyValue (defaultValueValue x)]
-
-
-prettyDirectives :: Directives -> Doc ()
-prettyDirectives x = P.sep (map prettyDirective (NonEmpty.toList (directivesValue x)))
-
-
-prettyDirective :: Directive -> Doc ()
-prettyDirective x = P.sep (Maybe.catMaybes
-  [ Just (P.hcat [P.pretty "@", prettyName (directiveName x)])
-  , fmap prettyArguments (directiveArguments x)
-  ])
-
-
-prettyOperationType :: OperationType -> Doc ()
-prettyOperationType operationType = case operationType of
-  OperationTypeQuery -> P.pretty "query"
-  OperationTypeMutation -> P.pretty "mutation"
-  OperationTypeSubscription -> P.pretty "subscription"
-
-
-prettySelectionSet :: SelectionSet -> Doc ()
-prettySelectionSet x = P.braces (P.sep (map prettySelection (selectionSetValue x)))
-
-
-prettySelection :: Selection -> Doc ()
-prettySelection x = case x of
-  SelectionField y -> prettyField y
-  SelectionFragmentSpread y -> prettyFragmentSpread y
-  SelectionInlineFragment y -> prettyInlineFragment y
-
-
-prettyField :: Field -> Doc ()
-prettyField x = P.sep (Maybe.catMaybes
-  [ fmap prettyAlias (fieldAlias x)
-  , Just (prettyName (fieldName x))
-  , fmap prettyArguments (fieldArguments x)
-  , fmap prettyDirectives (fieldDirectives x)
-  , fmap prettySelectionSet (fieldSelectionSet x)
-  ])
-
-
-prettyAlias :: Alias -> Doc ()
-prettyAlias x = P.hcat [prettyName (aliasValue x), P.pretty ":"]
-
-
-prettyArguments :: Arguments -> Doc ()
-prettyArguments x = P.parens (P.sep (map prettyArgument (argumentsValue x)))
-
-
-prettyArgument :: Argument -> Doc ()
-prettyArgument x = P.sep
-  [ P.hcat [prettyName (argumentName x), P.pretty ":"]
-  , prettyValue (argumentValue x)
-  ]
-
-
-prettyValue :: Value -> Doc ()
-prettyValue x = case x of
-  ValueVariable y -> prettyVariable y
-  ValueInt y -> prettyInt y
-  ValueFloat y -> prettyFloat y
-  ValueString y -> prettyString y
-  ValueBoolean y -> prettyBoolean y
-  ValueNull -> prettyNull
-  ValueEnum y -> prettyEnum y
-  ValueList y -> prettyList y
-  ValueObject y -> prettyObject y
-
-
-prettyVariable :: Variable -> Doc ()
-prettyVariable x = P.hcat [P.pretty "$", prettyName (variableValue x)]
-
-
-prettyInt :: Integer -> Doc ()
-prettyInt = P.pretty
-
-
-prettyFloat :: Scientific -> Doc ()
-prettyFloat x = P.pretty (Builder.toLazyText (Scientific.scientificBuilder x))
-
-
-prettyString :: Text -> Doc ()
-prettyString x = let
-  isAsciiPrintable c = c >= ' ' && c <= '~'
-  isBmp c = c <= '\xffff'
-  surrogatePair c = let
-    n = fromEnum c - 0x010000
-    h = 0x00d800 Bits..|. (Bits.shiftR n 10)
-    l = 0x00dc00 Bits..|. (n Bits..&. 0x0003ff)
-    in (h, l)
-  charBuilder c = case c of
-    '"' -> Builder.fromString "\\\""
-    '\\' -> Builder.fromString "\\\\"
-    _ -> if isAsciiPrintable c
-      then Builder.fromString [c]
-      else if isBmp c
-        then Builder.fromString (Printf.printf "\\u%04x" (fromEnum c))
-        else let
-          (h, l) = surrogatePair c
-          in Builder.fromString (Printf.printf "\\u%04x\\u%04x" h l)
-  in P.dquotes (P.pretty (Builder.toLazyText
-    (Text.foldl' (\b c -> mappend b (charBuilder c)) mempty x)))
-
-
-prettyBoolean :: Bool -> Doc ()
-prettyBoolean x = case x of
-  False -> P.pretty "false"
-  True -> P.pretty "true"
-
-
-prettyNull :: Doc ()
-prettyNull = P.pretty "null"
-
-
-prettyEnum :: Name -> Doc ()
-prettyEnum x = prettyName x
-
-
-prettyList :: [Value] -> Doc ()
-prettyList x = P.brackets (P.sep (map prettyValue x))
-
-
-prettyObject :: [ObjectField] -> Doc ()
-prettyObject x = P.braces (P.sep (map prettyObjectField x))
-
-
-prettyObjectField :: ObjectField -> Doc ()
-prettyObjectField x =
-  P.sep
-    [ P.hcat [prettyName (objectFieldName x), P.pretty ":"]
-    , prettyValue (objectFieldValue x)
+prettyOperationDefinition :: OperationDefinition -> Doc a
+prettyOperationDefinition OperationDefinition {..} =
+  sepMaybes
+    [ Just (prettyOperationType operationDefinitionOperationType)
+    , fmap prettyName operationDefinitionName
+    , fmap prettyVariableDefinitions operationDefinitionVariableDefinitions
+    , fmap prettyDirectives operationDefinitionDirectives
+    , Just (prettySelectionSet operationDefinitionSelectionSet)
     ]
 
+sepMaybes :: [Maybe (Doc a)] -> Doc a
+sepMaybes x = P.sep (Maybe.catMaybes x)
 
-prettyFragmentSpread :: FragmentSpread -> Doc ()
-prettyFragmentSpread x = P.sep (Maybe.catMaybes
-  [ Just (P.pretty "...")
-  , Just (prettyFragmentName (fragmentSpreadName x))
-  , fmap prettyDirectives (fragmentSpreadDirectives x)
-  ])
+prettyName :: Name -> Doc a
+prettyName Name {..} = P.pretty nameValue
 
+prettyVariableDefinitions :: VariableDefinitions -> Doc a
+prettyVariableDefinitions VariableDefinitions {..} =
+  P.parens (P.sep (map prettyVariableDefinition variableDefinitionsValue))
 
-prettyFragmentName :: FragmentName -> Doc ()
-prettyFragmentName x = prettyName (fragmentNameValue x)
+prettyVariableDefinition :: VariableDefinition -> Doc a
+prettyVariableDefinition VariableDefinition {..} =
+  sepMaybes
+    [ Just (P.hcat [prettyVariable variableDefinitionVariable, P.pretty ":"])
+    , Just (prettyType variableDefinitionType)
+    , fmap prettyDefaultValue variableDefinitionDefaultValue
+    ]
 
+prettyType :: Type -> Doc a
+prettyType x =
+  case x of
+    TypeNamed y -> prettyNamedType y
+    TypeList y -> prettyListType y
+    TypeNonNull y -> prettyNonNullType y
 
-prettyInlineFragment :: InlineFragment -> Doc ()
-prettyInlineFragment x = P.sep (Maybe.catMaybes
-  [ Just (P.pretty "...")
-  , fmap prettyTypeCondition (inlineFragmentTypeCondition x)
-  , fmap prettyDirectives (inlineFragmentDirectives x)
-  , Just (prettySelectionSet (inlineFragmentSelectionSet x))
-  ])
+prettyNamedType :: NamedType -> Doc a
+prettyNamedType NamedType {..} = prettyName namedTypeValue
 
+prettyListType :: ListType -> Doc a
+prettyListType ListType {..} = P.brackets (prettyType listTypeValue)
 
-prettyTypeCondition :: TypeCondition -> Doc ()
-prettyTypeCondition x = P.sep
-  [ P.pretty "on"
-  , prettyNamedType (typeConditionValue x)
-  ]
+prettyNonNullType :: NonNullType -> Doc a
+prettyNonNullType x =
+  case x of
+    NonNullTypeNamed y -> P.hcat [prettyNamedType y, P.pretty "!"]
+    NonNullTypeList y -> P.hcat [prettyListType y, P.pretty "!"]
 
+prettyDefaultValue :: DefaultValue -> Doc a
+prettyDefaultValue DefaultValue {..} =
+  P.sep [P.pretty "=", prettyValue defaultValueValue]
 
-prettyFragmentDefinition :: FragmentDefinition -> Doc ()
-prettyFragmentDefinition x = P.sep (Maybe.catMaybes
-  [ Just (P.pretty "fragment")
-  , Just (prettyFragmentName (fragmentName x))
-  , Just (prettyTypeCondition (fragmentTypeCondition x))
-  , fmap prettyDirectives (fragmentDirectives x)
-  , Just (prettySelectionSet (fragmentSelectionSet x))
-  ])
+prettyDirectives :: Directives -> Doc a
+prettyDirectives Directives {..} =
+  P.sep (map prettyDirective (NonEmpty.toList directivesValue))
 
+prettyDirective :: Directive -> Doc a
+prettyDirective Directive {..} =
+  sepMaybes
+    [ Just (P.hcat [P.pretty "@", prettyName directiveName])
+    , fmap prettyArguments directiveArguments
+    ]
 
-prettyTypeSystemDefinition :: TypeSystemDefinition -> Doc ()
-prettyTypeSystemDefinition x = case x of
-  TypeSystemDefinitionSchema y -> prettySchemaDefinition y
-  TypeSystemDefinitionType y -> prettyTypeDefinition y
-  TypeSystemDefinitionTypeExtension y -> prettyTypeExtensionDefinition y
-  TypeSystemDefinitionDirective y -> prettyDirectiveDefinition y
+prettyOperationType :: OperationType -> Doc a
+prettyOperationType operationType =
+  case operationType of
+    OperationTypeQuery -> P.pretty "query"
+    OperationTypeMutation -> P.pretty "mutation"
+    OperationTypeSubscription -> P.pretty "subscription"
 
+prettySelectionSet :: SelectionSet -> Doc a
+prettySelectionSet SelectionSet {..} =
+  P.braces (P.sep (map prettySelection selectionSetValue))
 
-prettySchemaDefinition :: SchemaDefinition -> Doc ()
-prettySchemaDefinition x = P.sep (Maybe.catMaybes
-  [ Just (P.pretty "schema")
-  , fmap prettyDirectives (schemaDefinitionDirectives x)
-  , Just (prettyOperationTypeDefinitions (schemaDefinitionOperationTypes x))
-  ])
+prettySelection :: Selection -> Doc a
+prettySelection x =
+  case x of
+    SelectionField y -> prettyField y
+    SelectionFragmentSpread y -> prettyFragmentSpread y
+    SelectionInlineFragment y -> prettyInlineFragment y
 
+prettyField :: Field -> Doc a
+prettyField Field {..} =
+  sepMaybes
+    [ fmap prettyAlias fieldAlias
+    , Just (prettyName fieldName)
+    , fmap prettyArguments fieldArguments
+    , fmap prettyDirectives fieldDirectives
+    , fmap prettySelectionSet fieldSelectionSet
+    ]
 
-prettyOperationTypeDefinitions :: OperationTypeDefinitions -> Doc ()
-prettyOperationTypeDefinitions x =
-  P.braces (P.sep (map prettyOperationTypeDefinition (operationTypeDefinitionsValue x)))
+prettyAlias :: Alias -> Doc a
+prettyAlias Alias {..} = P.hcat [prettyName aliasValue, P.pretty ":"]
 
+prettyArguments :: Arguments -> Doc a
+prettyArguments Arguments {..} =
+  P.parens (P.sep (map prettyArgument argumentsValue))
 
-prettyOperationTypeDefinition :: OperationTypeDefinition -> Doc ()
-prettyOperationTypeDefinition x = P.sep
-  [ P.hcat [prettyOperationType (operationTypeDefinitionOperation x), P.pretty ":"]
-  , prettyNamedType (operationTypeDefinitionType x)
-  ]
+prettyArgument :: Argument -> Doc a
+prettyArgument Argument {..} =
+  P.sep
+    [P.hcat [prettyName argumentName, P.pretty ":"], prettyValue argumentValue]
 
+prettyValue :: Value -> Doc a
+prettyValue x =
+  case x of
+    ValueVariable y -> prettyVariable y
+    ValueInt y -> prettyInt y
+    ValueFloat y -> prettyFloat y
+    ValueString y -> prettyString y
+    ValueBoolean y -> prettyBoolean y
+    ValueNull -> prettyNull
+    ValueEnum y -> prettyEnum y
+    ValueList y -> prettyList y
+    ValueObject y -> prettyObject y
 
-prettyTypeDefinition :: TypeDefinition -> Doc ()
-prettyTypeDefinition x = case x of
-  TypeDefinitionScalar y -> prettyScalarTypeDefinition y
-  TypeDefinitionObject y -> prettyObjectTypeDefinition y
-  TypeDefinitionInterface y -> prettyInterfaceTypeDefinition y
-  TypeDefinitionUnion y -> prettyUnionTypeDefinition y
-  TypeDefinitionEnum y -> prettyEnumTypeDefinition y
-  TypeDefinitionInputObject y -> prettyInputObjectTypeDefinition y
+prettyVariable :: Variable -> Doc a
+prettyVariable Variable {..} = P.hcat [P.pretty "$", prettyName variableValue]
 
+prettyInt :: Integer -> Doc a
+prettyInt = P.pretty
 
-prettyScalarTypeDefinition :: ScalarTypeDefinition -> Doc ()
-prettyScalarTypeDefinition x = P.sep (Maybe.catMaybes
-  [ Just (P.pretty "scalar")
-  , Just (prettyName (scalarTypeDefinitionName x))
-  , fmap prettyDirectives (scalarTypeDefinitionDirectives x)
-  ])
+prettyFloat :: Scientific -> Doc a
+prettyFloat x = P.pretty (Builder.toLazyText (Scientific.scientificBuilder x))
 
+prettyString :: Text -> Doc a
+prettyString x =
+  P.dquotes
+    (P.pretty
+       (Builder.toLazyText
+          (Text.foldl' (\b c -> mappend b (charBuilder c)) mempty x)))
 
-prettyObjectTypeDefinition :: ObjectTypeDefinition -> Doc ()
-prettyObjectTypeDefinition x = P.sep (Maybe.catMaybes
-  [ Just (P.pretty "type")
-  , Just (prettyName (objectTypeDefinitionName x))
-  , fmap prettyInterfaces (objectTypeDefinitionInterfaces x)
-  , fmap prettyDirectives (objectTypeDefinitionDirectives x)
-  , Just (prettyFieldDefinitions (objectTypeDefinitionFields x))
-  ])
+charBuilder :: Char -> Builder
+charBuilder c =
+  case c of
+    '"' -> Builder.fromString "\\\""
+    '\\' -> Builder.fromString "\\\\"
+    _
+      | asciiPrintable c -> Builder.fromString [c]
+      | bmp c -> Builder.fromString (Printf.printf "\\u%04x" (fromEnum c))
+      | otherwise ->
+        let (h, l) = surrogatePair c
+        in Builder.fromString (Printf.printf "\\u%04x\\u%04x" h l)
 
+asciiPrintable :: Char -> Bool
+asciiPrintable c = ' ' <= c && c <= '~'
 
-prettyInterfaces :: Interfaces -> Doc ()
-prettyInterfaces x =
-  P.sep (P.pretty "implements" : map prettyNamedType (NonEmpty.toList (interfacesValue x)))
+bmp :: Char -> Bool
+bmp c = c <= '\xffff'
 
+surrogatePair :: Char -> (Int, Int)
+surrogatePair c =
+  let n = fromEnum c - 0x010000
+      h = 0x00d800 Bits..|. Bits.shiftR n 10
+      l = 0x00dc00 Bits..|. (n Bits..&. 0x0003ff)
+  in (h, l)
 
-prettyFieldDefinitions :: FieldDefinitions -> Doc ()
-prettyFieldDefinitions x =
-  P.braces (P.sep (map prettyFieldDefinition (fieldDefinitionsValue x)))
+prettyBoolean :: Bool -> Doc a
+prettyBoolean x =
+  if x
+    then P.pretty "true"
+    else P.pretty "false"
 
+prettyNull :: Doc a
+prettyNull = P.pretty "null"
 
-prettyFieldDefinition :: FieldDefinition -> Doc ()
-prettyFieldDefinition x = P.sep (Maybe.catMaybes
-  [ Just (P.hcat (Maybe.catMaybes
-    [ Just (prettyName (fieldDefinitionName x))
-    , fmap prettyInputValueDefinitions (fieldDefinitionArguments x)
-    , Just (P.pretty ":")
-    ]))
-  , Just (prettyType (fieldDefinitionType x))
-  , fmap prettyDirectives (fieldDefinitionDirectives x)
-  ])
+prettyEnum :: Name -> Doc a
+prettyEnum = prettyName
 
+prettyList :: [Value] -> Doc a
+prettyList x = P.brackets (P.sep (map prettyValue x))
 
-prettyInputValueDefinitions :: InputValueDefinitions -> Doc ()
-prettyInputValueDefinitions x =
-  P.parens (P.sep (map prettyInputValueDefinition (inputValueDefinitionsValue x)))
+prettyObject :: [ObjectField] -> Doc a
+prettyObject x = P.braces (P.sep (map prettyObjectField x))
 
+prettyObjectField :: ObjectField -> Doc a
+prettyObjectField ObjectField {..} =
+  P.sep
+    [ P.hcat [prettyName objectFieldName, P.pretty ":"]
+    , prettyValue objectFieldValue
+    ]
 
-prettyInputValueDefinition :: InputValueDefinition -> Doc ()
-prettyInputValueDefinition x = P.sep (Maybe.catMaybes
-  [ Just (P.hcat
-    [ prettyName (inputValueDefinitionName x)
-    , P.pretty ":"
-    ])
-  , Just (prettyType (inputValueDefinitionType x))
-  , fmap prettyDefaultValue (inputValueDefinitionDefaultValue x)
-  , fmap prettyDirectives (inputValueDefinitionDirectives x)
-  ])
+prettyFragmentSpread :: FragmentSpread -> Doc a
+prettyFragmentSpread FragmentSpread {..} =
+  sepMaybes
+    [ Just (P.pretty "...")
+    , Just (prettyFragmentName fragmentSpreadName)
+    , fmap prettyDirectives fragmentSpreadDirectives
+    ]
 
+prettyFragmentName :: FragmentName -> Doc a
+prettyFragmentName FragmentName {..} = prettyName fragmentNameValue
 
-prettyInterfaceTypeDefinition :: InterfaceTypeDefinition -> Doc ()
-prettyInterfaceTypeDefinition x = P.sep (Maybe.catMaybes
-  [ Just (P.pretty "interface")
-  , Just (prettyName (interfaceTypeDefinitionName x))
-  , fmap prettyDirectives (interfaceTypeDefinitionDirectives x)
-  , Just (prettyFieldDefinitions (interfaceTypeDefinitionFields x))
-  ])
+prettyInlineFragment :: InlineFragment -> Doc a
+prettyInlineFragment InlineFragment {..} =
+  sepMaybes
+    [ Just (P.pretty "...")
+    , fmap prettyTypeCondition inlineFragmentTypeCondition
+    , fmap prettyDirectives inlineFragmentDirectives
+    , Just (prettySelectionSet inlineFragmentSelectionSet)
+    ]
 
+prettyTypeCondition :: TypeCondition -> Doc a
+prettyTypeCondition TypeCondition {..} =
+  P.sep [P.pretty "on", prettyNamedType typeConditionValue]
 
-prettyUnionTypeDefinition :: UnionTypeDefinition -> Doc ()
-prettyUnionTypeDefinition x = P.sep (Maybe.catMaybes
-  [ Just (P.pretty "union")
-  , Just (prettyName (unionTypeDefinitionName x))
-  , fmap prettyDirectives (unionTypeDefinitionDirectives x)
-  , Just (P.pretty "=")
-  , Just (prettyUnionTypes (unionTypeDefinitionTypes x))
-  ])
+prettyFragmentDefinition :: FragmentDefinition -> Doc a
+prettyFragmentDefinition FragmentDefinition {..} =
+  sepMaybes
+    [ Just (P.pretty "fragment")
+    , Just (prettyFragmentName fragmentName)
+    , Just (prettyTypeCondition fragmentTypeCondition)
+    , fmap prettyDirectives fragmentDirectives
+    , Just (prettySelectionSet fragmentSelectionSet)
+    ]
 
+prettyTypeSystemDefinition :: TypeSystemDefinition -> Doc a
+prettyTypeSystemDefinition x =
+  case x of
+    TypeSystemDefinitionSchema y -> prettySchemaDefinition y
+    TypeSystemDefinitionType y -> prettyTypeDefinition y
+    TypeSystemDefinitionTypeExtension y -> prettyTypeExtensionDefinition y
+    TypeSystemDefinitionDirective y -> prettyDirectiveDefinition y
 
-prettyUnionTypes :: UnionTypes -> Doc ()
-prettyUnionTypes x = P.encloseSep mempty mempty (mconcat [P.space, P.pretty "|", P.space])
-  (map prettyNamedType (NonEmpty.toList (unionTypesValue x)))
+prettySchemaDefinition :: SchemaDefinition -> Doc a
+prettySchemaDefinition SchemaDefinition {..} =
+  sepMaybes
+    [ Just (P.pretty "schema")
+    , fmap prettyDirectives schemaDefinitionDirectives
+    , Just (prettyOperationTypeDefinitions schemaDefinitionOperationTypes)
+    ]
 
+prettyOperationTypeDefinitions :: OperationTypeDefinitions -> Doc a
+prettyOperationTypeDefinitions OperationTypeDefinitions {..} =
+  P.braces
+    (P.sep (map prettyOperationTypeDefinition operationTypeDefinitionsValue))
 
-prettyEnumTypeDefinition :: EnumTypeDefinition -> Doc ()
-prettyEnumTypeDefinition x = P.sep (Maybe.catMaybes
-  [ Just (P.pretty "enum")
-  , Just (prettyName (enumTypeDefinitionName x))
-  , fmap prettyDirectives (enumTypeDefinitionDirectives x)
-  , Just (prettyEnumValues (enumTypeDefinitionValues x))
-  ])
+prettyOperationTypeDefinition :: OperationTypeDefinition -> Doc a
+prettyOperationTypeDefinition OperationTypeDefinition {..} =
+  P.sep
+    [ P.hcat
+        [prettyOperationType operationTypeDefinitionOperation, P.pretty ":"]
+    , prettyNamedType operationTypeDefinitionType
+    ]
 
+prettyTypeDefinition :: TypeDefinition -> Doc a
+prettyTypeDefinition x =
+  case x of
+    TypeDefinitionScalar y -> prettyScalarTypeDefinition y
+    TypeDefinitionObject y -> prettyObjectTypeDefinition y
+    TypeDefinitionInterface y -> prettyInterfaceTypeDefinition y
+    TypeDefinitionUnion y -> prettyUnionTypeDefinition y
+    TypeDefinitionEnum y -> prettyEnumTypeDefinition y
+    TypeDefinitionInputObject y -> prettyInputObjectTypeDefinition y
 
-prettyEnumValues :: EnumValues -> Doc ()
-prettyEnumValues x =
-  P.braces (P.sep (map prettyEnumValueDefinition (enumValuesValue x)))
+prettyScalarTypeDefinition :: ScalarTypeDefinition -> Doc a
+prettyScalarTypeDefinition ScalarTypeDefinition {..} =
+  sepMaybes
+    [ Just (P.pretty "scalar")
+    , Just (prettyName scalarTypeDefinitionName)
+    , fmap prettyDirectives scalarTypeDefinitionDirectives
+    ]
 
+prettyObjectTypeDefinition :: ObjectTypeDefinition -> Doc a
+prettyObjectTypeDefinition ObjectTypeDefinition {..} =
+  sepMaybes
+    [ Just (P.pretty "type")
+    , Just (prettyName objectTypeDefinitionName)
+    , fmap prettyInterfaces objectTypeDefinitionInterfaces
+    , fmap prettyDirectives objectTypeDefinitionDirectives
+    , Just (prettyFieldDefinitions objectTypeDefinitionFields)
+    ]
 
-prettyEnumValueDefinition :: EnumValueDefinition -> Doc ()
-prettyEnumValueDefinition x = P.sep (Maybe.catMaybes
-  [ Just (prettyName (enumValueDefinitionName x))
-  , fmap prettyDirectives (enumValueDefinitionDirectives x)
-  ])
+prettyInterfaces :: Interfaces -> Doc a
+prettyInterfaces Interfaces {..} =
+  P.sep
+    (P.pretty "implements" :
+     map prettyNamedType (NonEmpty.toList interfacesValue))
 
+prettyFieldDefinitions :: FieldDefinitions -> Doc a
+prettyFieldDefinitions FieldDefinitions {..} =
+  P.braces (P.sep (map prettyFieldDefinition fieldDefinitionsValue))
 
-prettyInputObjectTypeDefinition :: InputObjectTypeDefinition -> Doc ()
-prettyInputObjectTypeDefinition x = P.sep (Maybe.catMaybes
-  [ Just (P.pretty "input")
-  , Just (prettyName (inputObjectTypeDefinitionName x))
-  , fmap prettyDirectives (inputObjectTypeDefinitionDirectives x)
-  , Just (prettyInputFieldDefinitions (inputObjectTypeDefinitionFields x))
-  ])
+prettyFieldDefinition :: FieldDefinition -> Doc a
+prettyFieldDefinition FieldDefinition {..} =
+  sepMaybes
+    [ Just
+        (P.hcat
+           (Maybe.catMaybes
+              [ Just (prettyName fieldDefinitionName)
+              , fmap prettyInputValueDefinitions fieldDefinitionArguments
+              , Just (P.pretty ":")
+              ]))
+    , Just (prettyType fieldDefinitionType)
+    , fmap prettyDirectives fieldDefinitionDirectives
+    ]
 
+prettyInputValueDefinitions :: InputValueDefinitions -> Doc a
+prettyInputValueDefinitions InputValueDefinitions {..} =
+  P.parens (P.sep (map prettyInputValueDefinition inputValueDefinitionsValue))
 
-prettyInputFieldDefinitions :: InputFieldDefinitions -> Doc ()
-prettyInputFieldDefinitions x =
-  P.braces (P.sep (map prettyInputValueDefinition (inputFieldDefinitionsValue x)))
+prettyInputValueDefinition :: InputValueDefinition -> Doc a
+prettyInputValueDefinition InputValueDefinition {..} =
+  sepMaybes
+    [ Just (P.hcat [prettyName inputValueDefinitionName, P.pretty ":"])
+    , Just (prettyType inputValueDefinitionType)
+    , fmap prettyDefaultValue inputValueDefinitionDefaultValue
+    , fmap prettyDirectives inputValueDefinitionDirectives
+    ]
 
+prettyInterfaceTypeDefinition :: InterfaceTypeDefinition -> Doc a
+prettyInterfaceTypeDefinition InterfaceTypeDefinition {..} =
+  sepMaybes
+    [ Just (P.pretty "interface")
+    , Just (prettyName interfaceTypeDefinitionName)
+    , fmap prettyDirectives interfaceTypeDefinitionDirectives
+    , Just (prettyFieldDefinitions interfaceTypeDefinitionFields)
+    ]
 
-prettyTypeExtensionDefinition :: TypeExtensionDefinition -> Doc ()
-prettyTypeExtensionDefinition x = P.sep
-  [ P.pretty "extend"
-  , prettyObjectTypeDefinition (typeExtensionDefinitionValue x)
-  ]
+prettyUnionTypeDefinition :: UnionTypeDefinition -> Doc a
+prettyUnionTypeDefinition UnionTypeDefinition {..} =
+  sepMaybes
+    [ Just (P.pretty "union")
+    , Just (prettyName unionTypeDefinitionName)
+    , fmap prettyDirectives unionTypeDefinitionDirectives
+    , Just (P.pretty "=")
+    , Just (prettyUnionTypes unionTypeDefinitionTypes)
+    ]
 
+prettyUnionTypes :: UnionTypes -> Doc a
+prettyUnionTypes UnionTypes {..} =
+  P.encloseSep
+    mempty
+    mempty
+    (mconcat [P.space, P.pretty "|", P.space])
+    (map prettyNamedType (NonEmpty.toList unionTypesValue))
 
-prettyDirectiveDefinition :: DirectiveDefinition -> Doc ()
-prettyDirectiveDefinition x = P.sep (Maybe.catMaybes
-  [ Just (P.pretty "directive")
-  , Just (P.hcat [P.pretty "@", prettyName (directiveDefinitionName x)])
-  , fmap prettyInputValueDefinitions (directiveDefinitionArguments x)
-  , Just (P.pretty "on")
-  , Just (prettyDirectiveLocations (directiveDefinitionLocations x))
-  ])
+prettyEnumTypeDefinition :: EnumTypeDefinition -> Doc a
+prettyEnumTypeDefinition EnumTypeDefinition {..} =
+  sepMaybes
+    [ Just (P.pretty "enum")
+    , Just (prettyName enumTypeDefinitionName)
+    , fmap prettyDirectives enumTypeDefinitionDirectives
+    , Just (prettyEnumValues enumTypeDefinitionValues)
+    ]
 
+prettyEnumValues :: EnumValues -> Doc a
+prettyEnumValues EnumValues {..} =
+  P.braces (P.sep (map prettyEnumValueDefinition enumValuesValue))
 
-prettyDirectiveLocations :: DirectiveLocations -> Doc ()
-prettyDirectiveLocations x = P.encloseSep mempty mempty (mconcat [P.space, P.pretty "|", P.space])
-  (map prettyName (NonEmpty.toList (directiveLocationsValue x)))
+prettyEnumValueDefinition :: EnumValueDefinition -> Doc a
+prettyEnumValueDefinition EnumValueDefinition {..} =
+  sepMaybes
+    [ Just (prettyName enumValueDefinitionName)
+    , fmap prettyDirectives enumValueDefinitionDirectives
+    ]
+
+prettyInputObjectTypeDefinition :: InputObjectTypeDefinition -> Doc a
+prettyInputObjectTypeDefinition InputObjectTypeDefinition {..} =
+  sepMaybes
+    [ Just (P.pretty "input")
+    , Just (prettyName inputObjectTypeDefinitionName)
+    , fmap prettyDirectives inputObjectTypeDefinitionDirectives
+    , Just (prettyInputFieldDefinitions inputObjectTypeDefinitionFields)
+    ]
+
+prettyInputFieldDefinitions :: InputFieldDefinitions -> Doc a
+prettyInputFieldDefinitions InputFieldDefinitions {..} =
+  P.braces (P.sep (map prettyInputValueDefinition inputFieldDefinitionsValue))
+
+prettyTypeExtensionDefinition :: TypeExtensionDefinition -> Doc a
+prettyTypeExtensionDefinition TypeExtensionDefinition {..} =
+  P.sep
+    [P.pretty "extend", prettyObjectTypeDefinition typeExtensionDefinitionValue]
+
+prettyDirectiveDefinition :: DirectiveDefinition -> Doc a
+prettyDirectiveDefinition DirectiveDefinition {..} =
+  sepMaybes
+    [ Just (P.pretty "directive")
+    , Just (P.hcat [P.pretty "@", prettyName directiveDefinitionName])
+    , fmap prettyInputValueDefinitions directiveDefinitionArguments
+    , Just (P.pretty "on")
+    , Just (prettyDirectiveLocations directiveDefinitionLocations)
+    ]
+
+prettyDirectiveLocations :: DirectiveLocations -> Doc a
+prettyDirectiveLocations DirectiveLocations {..} =
+  P.encloseSep
+    mempty
+    mempty
+    (mconcat [P.space, P.pretty "|", P.space])
+    (map prettyName (NonEmpty.toList directiveLocationsValue))

--- a/tests/Grotesque/Generator.hs
+++ b/tests/Grotesque/Generator.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE RecordWildCards #-}
+
 module Grotesque.Generator where
 
 import Grotesque.Language
@@ -11,363 +14,356 @@ import qualified Data.Text as Text
 import qualified Hedgehog.Gen as H
 import qualified Hedgehog.Range as H
 
-
 genDocument :: Monad m => Gen m Document
-genDocument = Document
-  <$> H.list (H.linear 0 2) genDefinition
-
+genDocument = do
+  documentValue <- H.list (H.linear 0 2) genDefinition
+  pure Document {..}
 
 genDefinition :: Monad m => Gen m Definition
-genDefinition = H.choice
-  [ DefinitionOperation <$> genOperationDefinition
-  , DefinitionFragment <$> genFragmentDefinition
-  , DefinitionTypeSystem <$> genTypeSystemDefinition
-  ]
-
+genDefinition =
+  H.choice
+    [ fmap DefinitionOperation genOperationDefinition
+    , fmap DefinitionFragment genFragmentDefinition
+    , fmap DefinitionTypeSystem genTypeSystemDefinition
+    ]
 
 genOperationDefinition :: Monad m => Gen m OperationDefinition
-genOperationDefinition = OperationDefinition
-  <$> genOperationType
-  <*> H.maybe genName
-  <*> H.maybe genVariableDefinitions
-  <*> H.maybe genDirectives
-  <*> genSelectionSet
-
+genOperationDefinition = do
+  operationDefinitionOperationType <- genOperationType
+  operationDefinitionName <- H.maybe genName
+  operationDefinitionVariableDefinitions <- H.maybe genVariableDefinitions
+  operationDefinitionDirectives <- H.maybe genDirectives
+  operationDefinitionSelectionSet <- genSelectionSet
+  pure OperationDefinition {..}
 
 genOperationType :: Monad m => Gen m OperationType
 genOperationType = H.enumBounded
 
-
 genName :: Monad m => Gen m Name
-genName = (\h t -> Name (Text.pack (h : t)))
-  <$> H.element nameFirstChars
-  <*> H.list (H.linear 0 7) (H.element nameRestChars)
+genName = do
+  first <- H.element nameFirstChars
+  rest <- H.list (H.linear 0 7) (H.element nameRestChars)
+  pure (Name (Text.pack (first : rest)))
 
+nameFirstChars :: String
+nameFirstChars = concat ["_", ['A' .. 'Z'], ['a' .. 'z']]
 
-nameFirstChars :: [Char]
-nameFirstChars = concat [['_'], ['A' .. 'Z'], ['a' .. 'z']]
-
-
-nameRestChars :: [Char]
-nameRestChars = concat [nameFirstChars, ['0' .. '9']]
-
+nameRestChars :: String
+nameRestChars = nameFirstChars ++ ['0' .. '9']
 
 genVariableDefinitions :: Monad m => Gen m VariableDefinitions
-genVariableDefinitions = VariableDefinitions
-  <$> H.list (H.linear 0 2) genVariableDefinition
-
+genVariableDefinitions = do
+  variableDefinitionsValue <- H.list (H.linear 0 2) genVariableDefinition
+  pure VariableDefinitions {..}
 
 genVariableDefinition :: Monad m => Gen m VariableDefinition
-genVariableDefinition = VariableDefinition
-  <$> genVariable
-  <*> genType
-  <*> H.maybe genDefaultValue
-
+genVariableDefinition = do
+  variableDefinitionVariable <- genVariable
+  variableDefinitionType <- genType
+  variableDefinitionDefaultValue <- H.maybe genDefaultValue
+  pure VariableDefinition {..}
 
 genVariable :: Monad m => Gen m Variable
-genVariable = Variable
-  <$> genName
-
+genVariable = do
+  variableValue <- genName
+  pure Variable {..}
 
 genType :: Monad m => Gen m Type
-genType = H.choice
-  [ TypeNamed <$> genNamedType
-  , TypeList <$> genListType
-  , TypeNonNull <$> genNonNullType
-  ]
-
+genType =
+  H.choice
+    [ fmap TypeNamed genNamedType
+    , fmap TypeList genListType
+    , fmap TypeNonNull genNonNullType
+    ]
 
 genNamedType :: Monad m => Gen m NamedType
-genNamedType = NamedType <$> genName
-
+genNamedType = do
+  namedTypeValue <- genName
+  pure NamedType {..}
 
 genListType :: Monad m => Gen m ListType
-genListType = ListType <$> genType
-
+genListType = do
+  listTypeValue <- genType
+  pure ListType {..}
 
 genNonNullType :: Monad m => Gen m NonNullType
-genNonNullType = H.choice
-  [ NonNullTypeNamed <$> genNamedType
-  , NonNullTypeList <$> genListType
-  ]
-
+genNonNullType =
+  H.choice
+    [fmap NonNullTypeNamed genNamedType, fmap NonNullTypeList genListType]
 
 genDefaultValue :: Monad m => Gen m DefaultValue
-genDefaultValue = DefaultValue
-  <$> genValue
-
+genDefaultValue = do
+  defaultValueValue <- genValue
+  pure DefaultValue {..}
 
 genValue :: Monad m => Gen m Value
-genValue = H.choice
-  [ ValueVariable <$> genVariable
-  , ValueInt <$> genInt
-  , ValueFloat <$> genFloat
-  , ValueString <$> genString
-  , ValueBoolean <$> genBoolean
-  , pure ValueNull
-  , ValueEnum <$> genEnum
-  , ValueList <$> genList
-  , ValueObject <$> genObject
-  ]
-
+genValue =
+  H.choice
+    [ fmap ValueVariable genVariable
+    , fmap ValueInt genInt
+    , fmap ValueFloat genFloat
+    , fmap ValueString genString
+    , fmap ValueBoolean genBoolean
+    , pure ValueNull
+    , fmap ValueEnum genEnum
+    , fmap ValueList genList
+    , fmap ValueObject genObject
+    ]
 
 genInt :: Monad m => Gen m Integer
 genInt = H.integral (H.linearFrom 0 (-1000000000) 1000000000)
 
-
+-- TODO
 genFloat :: Monad m => Gen m Scientific
-genFloat = Scientific.fromFloatDigits
-  <$> H.double (H.linearFracFrom 0 (-1e9) 1e9)
-
+genFloat =
+  Scientific.fromFloatDigits <$> H.double (H.linearFracFrom 0 (-1e9) 1e9)
 
 genString :: Monad m => Gen m Text
 genString = H.text (H.linear 0 8) H.unicode
 
-
 genBoolean :: Monad m => Gen m Bool
 genBoolean = H.bool
-
 
 genEnum :: Monad m => Gen m Name
 genEnum = genName
 
-
 genList :: Monad m => Gen m [Value]
 genList = H.list (H.linear 0 2) genValue
-
 
 genObject :: Monad m => Gen m [ObjectField]
 genObject = H.list (H.linear 0 2) genObjectField
 
-
 genObjectField :: Monad m => Gen m ObjectField
-genObjectField = ObjectField
-  <$> genName
-  <*> genValue
-
+genObjectField = do
+  objectFieldName <- genName
+  objectFieldValue <- genValue
+  pure ObjectField {..}
 
 genDirectives :: Monad m => Gen m Directives
-genDirectives = Directives
-  <$> H.nonEmpty (H.linear 1 2) genDirective
-
+genDirectives = do
+  directivesValue <- H.nonEmpty (H.linear 1 2) genDirective
+  pure Directives {..}
 
 genDirective :: Monad m => Gen m Directive
-genDirective = Directive
-  <$> genName
-  <*> H.maybe genArguments
-
+genDirective = do
+  directiveName <- genName
+  directiveArguments <- H.maybe genArguments
+  pure Directive {..}
 
 genSelectionSet :: Monad m => Gen m SelectionSet
-genSelectionSet = SelectionSet
-  <$> H.list (H.linear 0 2) genSelection
-
+genSelectionSet = do
+  selectionSetValue <- H.list (H.linear 0 2) genSelection
+  pure SelectionSet {..}
 
 genSelection :: Monad m => Gen m Selection
-genSelection = H.choice
-  [ SelectionField <$> genField
-  , SelectionFragmentSpread <$> genFragmentSpread
-  , SelectionInlineFragment <$> genInlineFragment
-  ]
-
+genSelection =
+  H.choice
+    [ fmap SelectionField genField
+    , fmap SelectionFragmentSpread genFragmentSpread
+    , fmap SelectionInlineFragment genInlineFragment
+    ]
 
 genField :: Monad m => Gen m Field
-genField = Field
-  <$> H.maybe genAlias
-  <*> genName
-  <*> H.maybe genArguments
-  <*> H.maybe genDirectives
-  <*> H.maybe genSelectionSet
-
+genField = do
+  fieldAlias <- H.maybe genAlias
+  fieldName <- genName
+  fieldArguments <- H.maybe genArguments
+  fieldDirectives <- H.maybe genDirectives
+  fieldSelectionSet <- H.maybe genSelectionSet
+  pure Field {..}
 
 genAlias :: Monad m => Gen m Alias
-genAlias = Alias <$> genName
-
+genAlias = do
+  aliasValue <- genName
+  pure Alias {..}
 
 genArguments :: Monad m => Gen m Arguments
-genArguments = Arguments
-  <$> H.list (H.linear 0 2) genArgument
-
+genArguments = do
+  argumentsValue <- H.list (H.linear 0 2) genArgument
+  pure Arguments {..}
 
 genArgument :: Monad m => Gen m Argument
-genArgument = Argument
-  <$> genName
-  <*> genValue
-
+genArgument = do
+  argumentName <- genName
+  argumentValue <- genValue
+  pure Argument {..}
 
 genFragmentSpread :: Monad m => Gen m FragmentSpread
-genFragmentSpread = FragmentSpread
-  <$> genFragmentName
-  <*> H.maybe genDirectives
-
+genFragmentSpread = do
+  fragmentSpreadName <- genFragmentName
+  fragmentSpreadDirectives <- H.maybe genDirectives
+  pure FragmentSpread {..}
 
 genFragmentName :: Monad m => Gen m FragmentName
-genFragmentName = FragmentName
-  <$> genName
-
+genFragmentName = do
+  fragmentNameValue <- genName
+  pure FragmentName {..}
 
 genInlineFragment :: Monad m => Gen m InlineFragment
-genInlineFragment = InlineFragment
-  <$> H.maybe genTypeCondition
-  <*> H.maybe genDirectives
-  <*> genSelectionSet
-
+genInlineFragment = do
+  inlineFragmentTypeCondition <- H.maybe genTypeCondition
+  inlineFragmentDirectives <- H.maybe genDirectives
+  inlineFragmentSelectionSet <- genSelectionSet
+  pure InlineFragment {..}
 
 genTypeCondition :: Monad m => Gen m TypeCondition
-genTypeCondition = TypeCondition
-  <$> genNamedType
-
+genTypeCondition = do
+  typeConditionValue <- genNamedType
+  pure TypeCondition {..}
 
 genFragmentDefinition :: Monad m => Gen m FragmentDefinition
-genFragmentDefinition = FragmentDefinition
-  <$> genFragmentName
-  <*> genTypeCondition
-  <*> H.maybe genDirectives
-  <*> genSelectionSet
-
+genFragmentDefinition = do
+  fragmentName <- genFragmentName
+  fragmentTypeCondition <- genTypeCondition
+  fragmentDirectives <- H.maybe genDirectives
+  fragmentSelectionSet <- genSelectionSet
+  pure FragmentDefinition {..}
 
 genTypeSystemDefinition :: Monad m => Gen m TypeSystemDefinition
-genTypeSystemDefinition = H.choice
-  [ TypeSystemDefinitionSchema <$> genSchemaDefinition
-  , TypeSystemDefinitionType <$> genTypeDefinition
-  , TypeSystemDefinitionTypeExtension <$> genTypeExtensionDefinition
-  , TypeSystemDefinitionDirective <$> genDirectiveDefinition
-  ]
-
+genTypeSystemDefinition =
+  H.choice
+    [ fmap TypeSystemDefinitionSchema genSchemaDefinition
+    , fmap TypeSystemDefinitionType genTypeDefinition
+    , fmap TypeSystemDefinitionTypeExtension genTypeExtensionDefinition
+    , fmap TypeSystemDefinitionDirective genDirectiveDefinition
+    ]
 
 genSchemaDefinition :: Monad m => Gen m SchemaDefinition
-genSchemaDefinition = SchemaDefinition
-  <$> H.maybe genDirectives
-  <*> genOperationTypeDefinitions
-
+genSchemaDefinition = do
+  schemaDefinitionDirectives <- H.maybe genDirectives
+  schemaDefinitionOperationTypes <- genOperationTypeDefinitions
+  pure SchemaDefinition {..}
 
 genOperationTypeDefinitions :: Monad m => Gen m OperationTypeDefinitions
-genOperationTypeDefinitions = OperationTypeDefinitions
-  <$> H.list (H.linear 0 2) genOperationTypeDefinition
-
+genOperationTypeDefinitions = do
+  operationTypeDefinitionsValue <-
+    H.list (H.linear 0 2) genOperationTypeDefinition
+  pure OperationTypeDefinitions {..}
 
 genOperationTypeDefinition :: Monad m => Gen m OperationTypeDefinition
-genOperationTypeDefinition = OperationTypeDefinition
-  <$> genOperationType
-  <*> genNamedType
-
+genOperationTypeDefinition = do
+  operationTypeDefinitionOperation <- genOperationType
+  operationTypeDefinitionType <- genNamedType
+  pure OperationTypeDefinition {..}
 
 genTypeDefinition :: Monad m => Gen m TypeDefinition
-genTypeDefinition = H.choice
-  [ TypeDefinitionScalar <$> genScalarTypeDefinition
-  , TypeDefinitionObject <$> genObjectTypeDefinition
-  , TypeDefinitionInterface <$> genInterfaceTypeDefinition
-  , TypeDefinitionUnion <$> genUnionTypeDefinition
-  , TypeDefinitionEnum <$> genEnumTypeDefinition
-  , TypeDefinitionInputObject <$> genInputObjectTypeDefinition
-  ]
-
+genTypeDefinition =
+  H.choice
+    [ fmap TypeDefinitionScalar genScalarTypeDefinition
+    , fmap TypeDefinitionObject genObjectTypeDefinition
+    , fmap TypeDefinitionInterface genInterfaceTypeDefinition
+    , fmap TypeDefinitionUnion genUnionTypeDefinition
+    , fmap TypeDefinitionEnum genEnumTypeDefinition
+    , fmap TypeDefinitionInputObject genInputObjectTypeDefinition
+    ]
 
 genScalarTypeDefinition :: Monad m => Gen m ScalarTypeDefinition
-genScalarTypeDefinition = ScalarTypeDefinition
-  <$> genName
-  <*> H.maybe genDirectives
-
+genScalarTypeDefinition = do
+  scalarTypeDefinitionName <- genName
+  scalarTypeDefinitionDirectives <- H.maybe genDirectives
+  pure ScalarTypeDefinition {..}
 
 genObjectTypeDefinition :: Monad m => Gen m ObjectTypeDefinition
-genObjectTypeDefinition = ObjectTypeDefinition
-  <$> genName
-  <*> H.maybe genInterfaces
-  <*> H.maybe genDirectives
-  <*> genFieldDefinitions
-
+genObjectTypeDefinition = do
+  objectTypeDefinitionName <- genName
+  objectTypeDefinitionInterfaces <- H.maybe genInterfaces
+  objectTypeDefinitionDirectives <- H.maybe genDirectives
+  objectTypeDefinitionFields <- genFieldDefinitions
+  pure ObjectTypeDefinition {..}
 
 genInterfaces :: Monad m => Gen m Interfaces
-genInterfaces = Interfaces
-  <$> H.nonEmpty (H.linear 1 2) genNamedType
-
+genInterfaces = do
+  interfacesValue <- H.nonEmpty (H.linear 1 2) genNamedType
+  pure Interfaces {..}
 
 genFieldDefinitions :: Monad m => Gen m FieldDefinitions
-genFieldDefinitions = FieldDefinitions
-  <$> H.list (H.linear 0 2) genFieldDefinition
-
+genFieldDefinitions = do
+  fieldDefinitionsValue <- H.list (H.linear 0 2) genFieldDefinition
+  pure FieldDefinitions {..}
 
 genFieldDefinition :: Monad m => Gen m FieldDefinition
-genFieldDefinition = FieldDefinition
-  <$> genName
-  <*> H.maybe genInputValueDefinitions
-  <*> genType
-  <*> H.maybe genDirectives
-
+genFieldDefinition = do
+  fieldDefinitionName <- genName
+  fieldDefinitionArguments <- H.maybe genInputValueDefinitions
+  fieldDefinitionType <- genType
+  fieldDefinitionDirectives <- H.maybe genDirectives
+  pure FieldDefinition {..}
 
 genInputValueDefinitions :: Monad m => Gen m InputValueDefinitions
-genInputValueDefinitions = InputValueDefinitions
-  <$> H.list (H.linear 0 2) genInputValueDefinition
-
+genInputValueDefinitions = do
+  inputValueDefinitionsValue <- H.list (H.linear 0 2) genInputValueDefinition
+  pure InputValueDefinitions {..}
 
 genInputValueDefinition :: Monad m => Gen m InputValueDefinition
-genInputValueDefinition = InputValueDefinition
-  <$> genName
-  <*> genType
-  <*> H.maybe genDefaultValue
-  <*> H.maybe genDirectives
-
+genInputValueDefinition = do
+  inputValueDefinitionName <- genName
+  inputValueDefinitionType <- genType
+  inputValueDefinitionDefaultValue <- H.maybe genDefaultValue
+  inputValueDefinitionDirectives <- H.maybe genDirectives
+  pure InputValueDefinition {..}
 
 genInterfaceTypeDefinition :: Monad m => Gen m InterfaceTypeDefinition
-genInterfaceTypeDefinition = InterfaceTypeDefinition
-  <$> genName
-  <*> H.maybe genDirectives
-  <*> genFieldDefinitions
-
+genInterfaceTypeDefinition = do
+  interfaceTypeDefinitionName <- genName
+  interfaceTypeDefinitionDirectives <- H.maybe genDirectives
+  interfaceTypeDefinitionFields <- genFieldDefinitions
+  pure InterfaceTypeDefinition {..}
 
 genUnionTypeDefinition :: Monad m => Gen m UnionTypeDefinition
-genUnionTypeDefinition = UnionTypeDefinition
-  <$> genName
-  <*> H.maybe genDirectives
-  <*> genUnionTypes
-
+genUnionTypeDefinition = do
+  unionTypeDefinitionName <- genName
+  unionTypeDefinitionDirectives <- H.maybe genDirectives
+  unionTypeDefinitionTypes <- genUnionTypes
+  pure UnionTypeDefinition {..}
 
 genUnionTypes :: Monad m => Gen m UnionTypes
-genUnionTypes = UnionTypes
-  <$> H.nonEmpty (H.linear 1 2) genNamedType
-
+genUnionTypes = do
+  unionTypesValue <- H.nonEmpty (H.linear 1 2) genNamedType
+  pure UnionTypes {..}
 
 genEnumTypeDefinition :: Monad m => Gen m EnumTypeDefinition
-genEnumTypeDefinition = EnumTypeDefinition
-  <$> genName
-  <*> H.maybe genDirectives
-  <*> genEnumValues
-
+genEnumTypeDefinition = do
+  enumTypeDefinitionName <- genName
+  enumTypeDefinitionDirectives <- H.maybe genDirectives
+  enumTypeDefinitionValues <- genEnumValues
+  pure EnumTypeDefinition {..}
 
 genEnumValues :: Monad m => Gen m EnumValues
-genEnumValues = EnumValues
-  <$> H.list (H.linear 0 2) genEnumValueDefinition
-
+genEnumValues = do
+  enumValuesValue <- H.list (H.linear 0 2) genEnumValueDefinition
+  pure EnumValues {..}
 
 genEnumValueDefinition :: Monad m => Gen m EnumValueDefinition
-genEnumValueDefinition = EnumValueDefinition
-  <$> genName
-  <*> H.maybe genDirectives
-
+genEnumValueDefinition = do
+  enumValueDefinitionName <- genName
+  enumValueDefinitionDirectives <- H.maybe genDirectives
+  pure EnumValueDefinition {..}
 
 genInputObjectTypeDefinition :: Monad m => Gen m InputObjectTypeDefinition
-genInputObjectTypeDefinition = InputObjectTypeDefinition
-  <$> genName
-  <*> H.maybe genDirectives
-  <*> genInputFieldDefinitions
-
+genInputObjectTypeDefinition = do
+  inputObjectTypeDefinitionName <- genName
+  inputObjectTypeDefinitionDirectives <- H.maybe genDirectives
+  inputObjectTypeDefinitionFields <- genInputFieldDefinitions
+  pure InputObjectTypeDefinition {..}
 
 genInputFieldDefinitions :: Monad m => Gen m InputFieldDefinitions
-genInputFieldDefinitions = InputFieldDefinitions
-  <$> H.list (H.linear 0 2) genInputValueDefinition
-
+genInputFieldDefinitions = do
+  inputFieldDefinitionsValue <- H.list (H.linear 0 2) genInputValueDefinition
+  pure InputFieldDefinitions {..}
 
 genTypeExtensionDefinition :: Monad m => Gen m TypeExtensionDefinition
-genTypeExtensionDefinition = TypeExtensionDefinition
-  <$> genObjectTypeDefinition
-
+genTypeExtensionDefinition = do
+  typeExtensionDefinitionValue <- genObjectTypeDefinition
+  pure TypeExtensionDefinition {..}
 
 genDirectiveDefinition :: Monad m => Gen m DirectiveDefinition
-genDirectiveDefinition = DirectiveDefinition
-  <$> genName
-  <*> H.maybe genInputValueDefinitions
-  <*> genDirectiveLocations
-
+genDirectiveDefinition = do
+  directiveDefinitionName <- genName
+  directiveDefinitionArguments <- H.maybe genInputValueDefinitions
+  directiveDefinitionLocations <- genDirectiveLocations
+  pure DirectiveDefinition {..}
 
 genDirectiveLocations :: Monad m => Gen m DirectiveLocations
-genDirectiveLocations = DirectiveLocations
-  <$> H.nonEmpty (H.linear 1 2) genName
+genDirectiveLocations = do
+  directiveLocationsValue <- H.nonEmpty (H.linear 1 2) genName
+  pure DirectiveLocations {..}


### PR DESCRIPTION
This is an alternative to #1. Instead of switching everything over to the applicative style this sticks with the monadic style. It uses `ApplicativeDo` to have the same behavior as the applicative style but with the monadic style. And it uses `RecordWildCards` to keep things short. 